### PR TITLE
PAE-831-New param in Course endpoints that allows the sorting/ordering of the course_runs by start date

### DIFF
--- a/course_discovery/apps/api/filters.py
+++ b/course_discovery/apps/api/filters.py
@@ -183,25 +183,56 @@ class CourseRunFilter(FilterSetMixin, filters.FilterSet):
 
 
 class CourseRunOrderingFilter(OrderingFilter):
+    """This class applies a custom order to a CourseRun QuerySet.
+
+    It uses a ordering param called `course_runs_sort_by`.
+
+    Attributes:
+        ordering_param (str): The param that specifies the custom ordering.
+        allowed_custom_filters (:obj:`list` of :obj:`str`): List of allowed fields.
+
+    """
     ordering_param = 'course_runs_sort_by'
     allowed_custom_filters = ['key', 'start']
 
     def get_ordering(self, request, queryset, view):
-        params = request.query_params.get(self.ordering_param)
-        if params:
-            fields = [param.strip() for param in params.split(',')]
-            ordering = [f for f in fields if f.lstrip('-') in self.allowed_custom_filters]
-            if ordering:
-                return ordering
+        """Class methods that returns the ordering fields.
 
-        return self.get_default_ordering(view)
+        Args:
+            request: The request.
+            queryset: The CourseRun queryset.
+            view: The CourseRunViewset
+
+        Returns:
+             A empty array if no custom ordering is passed.
+             Else an array with the ordering fields.
+
+        """
+        params = request.query_params.get(self.ordering_param)
+
+        if not params:
+            return self.get_default_ordering(view)
+
+        fields = [param.strip() for param in params.split(',')]
+        ordering = [filter for filter in fields if filter.lstrip('-') in self.allowed_custom_filters]
+
+        return ordering if ordering else self.get_default_ordering(view)
 
     def filter_queryset(self, request, queryset, view):
-        ordering = self.get_ordering(request, queryset, view)
-        if ordering:
-            return queryset.order_by(*ordering)
+        """Class methods returns the ordered queryset.
 
-        return queryset
+        Args:
+            request: The request.
+            queryset: The CourseRun queryset.
+            view: The CourseRunViewset
+
+        Returns:
+            The ordered Queryset.
+
+        """
+        ordering = self.get_ordering(request, queryset, view)
+
+        return queryset.order_by(*ordering) if ordering else queryset.order_by('-start')
 
 
 class ProgramFilter(FilterSetMixin, filters.FilterSet):

--- a/course_discovery/apps/api/filters.py
+++ b/course_discovery/apps/api/filters.py
@@ -190,7 +190,6 @@ class CourseRunOrderingFilter(OrderingFilter):
     Attributes:
         ordering_param (str): The param that specifies the custom ordering.
         allowed_custom_filters (:obj:`list` of :obj:`str`): List of allowed fields.
-
     """
     ordering_param = 'course_runs_sort_by'
     allowed_custom_filters = ['key', 'start']
@@ -201,12 +200,11 @@ class CourseRunOrderingFilter(OrderingFilter):
         Args:
             request: The request.
             queryset: The CourseRun queryset.
-            view: The CourseRunViewset
+            view: The CourseRunViewset.
 
         Returns:
              A empty array if no custom ordering is passed.
              Else an array with the ordering fields.
-
         """
         params = request.query_params.get(self.ordering_param)
 
@@ -224,11 +222,10 @@ class CourseRunOrderingFilter(OrderingFilter):
         Args:
             request: The request.
             queryset: The CourseRun queryset.
-            view: The CourseRunViewset
+            view: The CourseRunViewset.
 
         Returns:
             The ordered Queryset.
-
         """
         ordering = self.get_ordering(request, queryset, view)
 

--- a/course_discovery/apps/api/v1/views/courses.py
+++ b/course_discovery/apps/api/v1/views/courses.py
@@ -138,6 +138,9 @@ class CourseViewSet(CompressedCacheResponseMixin, viewsets.ModelViewSet):
             if get_query_param(self.request, 'published_course_runs_only'):
                 course_runs = course_runs.filter(status=CourseRunStatus.Published)
 
+            # Apply an order to the course_runs by the parameter "course_runs_sort_by"
+            course_runs = filters.CourseRunOrderingFilter().filter_queryset(self.request, course_runs, CourseRunViewSet)
+
             if get_query_param(self.request, 'include_deleted_programs'):
                 programs = Program.objects.all()
             else:

--- a/course_discovery/apps/api/v1/views/courses.py
+++ b/course_discovery/apps/api/v1/views/courses.py
@@ -138,7 +138,7 @@ class CourseViewSet(CompressedCacheResponseMixin, viewsets.ModelViewSet):
             if get_query_param(self.request, 'published_course_runs_only'):
                 course_runs = course_runs.filter(status=CourseRunStatus.Published)
 
-            # Apply an order to the course_runs by the parameter "course_runs_sort_by"
+            # Apply an order to the course_runs by the parameter "course_runs_sort_by".
             course_runs = filters.CourseRunOrderingFilter().filter_queryset(self.request, course_runs, CourseRunViewSet)
 
             if get_query_param(self.request, 'include_deleted_programs'):


### PR DESCRIPTION
When someone does a request to the `api/v1/courses/{key}` endpoint in discovery. The course runs array in the resulting request is not implicitly ordered. Now there is a new param called `course_runs_sort_by` that when added, allows for the sorting ordering of those records. The param uses the same behavior as the ordering parameter in DRF. One can do `api/v1/courses/{key}/?course_runs_sort_by=-start` is one wants to order them in DESC or `api/v1/courses/edX%2BDemoX/?course_runs_sort_by=start` to order them in ASC.

Right now the only possible accepted fields are key and start, more fields could be added easily. 

[PAE-831](https://pearsonadvance.atlassian.net/browse/PAE-831) for reference.