### PR TITLE
PAE-831.2 - New param in Course endpoints that allows the sorting/ordering of the course_runs by start date

### DIFF
--- a/course_discovery/apps/api/filters.py
+++ b/course_discovery/apps/api/filters.py
@@ -229,7 +229,7 @@ class CourseRunOrderingFilter(OrderingFilter):
         """
         ordering = self.get_ordering(request, queryset, view)
 
-        return queryset.order_by(*ordering) if ordering else queryset.order_by('-start')
+        return queryset.order_by(*ordering) if ordering else queryset.order_by('start')
 
 
 class ProgramFilter(FilterSetMixin, filters.FilterSet):


### PR DESCRIPTION
This PR changes the default ordering to ASC for the course_runs nested field in the api/v1/course/{key}.