### PR TITLE
PADV-377 - Update inputs in build and push workflows

### DIFF
--- a/.github/workflows/ build-push-image-main.yml
+++ b/.github/workflows/ build-push-image-main.yml
@@ -1,4 +1,4 @@
-name: Tutor Build Action Test
+name: Tutor Build Action
 
 on:
   push:
@@ -20,8 +20,8 @@ jobs:
           python-version: ${{ vars.BUILD_PYTHON_VERSION }}
           tutor-version: ${{ vars.BUILD_TUTOR_VERSION }}
           path-image-to-be-built: 'env/plugins/discovery/build/discovery'
-          repository-name: ${{ vars.BUILD_MAIN_REPOSITORY_NAME }}
-          image-name: ${{ vars.BUILD_MAIN_IMAGE_NAME }}
+          organization-name: ${{ vars.BUILD_ORGANIZATION_NAME }}
+          repository-name: ${{ vars.BUILD_REPOSITORY_NAME }}
           image-tag: ${{ vars.DISCOVERY_TUTOR_PLUGIN_VERSION }}-${{ steps.current-time.outputs.formattedTime }}
           docker-username: ${{ secrets.DOCKERHUB_USERNAME }}
           docker-token: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -29,4 +29,5 @@ jobs:
           tutor-plugin-sources: '("git+https://github.com/overhangio/tutor-discovery.git@v${{ vars.DISCOVERY_TUTOR_PLUGIN_VERSION }}")'
           tutor-plugin-names: '("discovery")'
           tutor-pearson-plugin-url: ${{ vars.TUTOR_PEARSON_PLUGIN_URL }}
+          tutor-pearson-plugin-name: 'pearson-plugin-discovery-prod'
           gh-access-token: ${{ secrets.GH_ACCESS_TOKEN }}

--- a/.github/workflows/ build-push-image-stage.yml
+++ b/.github/workflows/ build-push-image-stage.yml
@@ -20,8 +20,8 @@ jobs:
           python-version: ${{ vars.BUILD_PYTHON_VERSION }}
           tutor-version: ${{ vars.BUILD_TUTOR_VERSION }}
           path-image-to-be-built: 'env/plugins/discovery/build/discovery'
-          repository-name: ${{ vars.BUILD_STAGE_REPOSITORY_NAME }}
-          image-name: ${{ vars.BUILD_STAGE_IMAGE_NAME }}
+          organization-name: ${{ vars.BUILD_ORGANIZATION_NAME }}
+          repository-name: ${{ vars.BUILD_REPOSITORY_NAME }}
           image-tag: ${{ vars.DISCOVERY_TUTOR_PLUGIN_VERSION }}-RC-${{ steps.current-time.outputs.formattedTime }}
           docker-username: ${{ secrets.DOCKERHUB_USERNAME }}
           docker-token: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -29,4 +29,5 @@ jobs:
           tutor-plugin-sources: '("git+https://github.com/overhangio/tutor-discovery.git@v${{ vars.DISCOVERY_TUTOR_PLUGIN_VERSION }}")'
           tutor-plugin-names: '("discovery")'
           tutor-pearson-plugin-url: ${{ vars.TUTOR_PEARSON_PLUGIN_URL }}
+          tutor-pearson-plugin-name: 'pearson-plugin-discovery-stg'
           gh-access-token: ${{ secrets.GH_ACCESS_TOKEN }}


### PR DESCRIPTION
## Ticket

https://agile-jira.pearson.com/browse/PADV-377

## Description

This PR changes some inputs as [tutor-build-image-action](https://github.com/Pearson-Advance/tutor-build-image-action/tree/vue/PADV-377) updated the names of its parameters.

## Type of Change

- [x] Change and add new input in workflow for prod.
- [x] Change and add new input in workflow for stage.

## How to test

- Create a test PR in the discovery repository.
- Merge this PR into the target branch.
- Check that the Github Action is triggered by the PR merge event.
- Check the output of the image build creation for any issues or silent issues.
-  When the process is complete, check the Docker Hub Pearson repository and verify that the image has been built (https://hub.docker.com/repository/docker/paops/discovery-tutor/general).
-  Use the image in a local environment to test it out.
- You can use this repo https://github.com/Pearson-Advance/discovery/tree/vue/PADV-356.tests to perform any tests

## Reviewers

- [x] @Squirrel18
- [x] @anfbermudezme 
