### PR TITLE
PADV-487 - Migrate Course Discovery to olive version.

### DIFF
--- a/course_discovery/apps/api/filters.py
+++ b/course_discovery/apps/api/filters.py
@@ -9,6 +9,7 @@ from django_filters import rest_framework as filters
 from dry_rest_permissions.generics import DRYPermissionFiltersBase
 from guardian.shortcuts import get_objects_for_user
 from rest_framework.exceptions import NotFound, PermissionDenied
+from rest_framework.filters import OrderingFilter
 
 from course_discovery.apps.api.utils import cast2int
 from course_discovery.apps.course_metadata.choices import CourseRunStatus, ProgramStatus
@@ -146,6 +147,56 @@ class CourseRunFilter(FilterSetMixin, filters.FilterSet):
     class Meta:
         model = CourseRun
         fields = ('keys', 'hidden', 'license',)
+
+
+class CourseRunOrderingFilter(OrderingFilter):
+    """This class applies a custom order to a CourseRun QuerySet.
+
+    It uses a ordering param called `course_runs_sort_by`.
+
+    Attributes:
+        ordering_param (str): The param that specifies the custom ordering.
+        allowed_custom_filters (:obj:`list` of :obj:`str`): List of allowed fields.
+    """
+    ordering_param = 'course_runs_sort_by'
+    allowed_custom_filters = ['key', 'start']
+
+    def get_ordering(self, request, queryset, view):
+        """Class methods that returns the ordering fields.
+
+        Args:
+            request: The request.
+            queryset: The CourseRun queryset.
+            view: The CourseRunViewset.
+
+        Returns:
+             A empty array if no custom ordering is passed.
+             Else an array with the ordering fields.
+        """
+        params = request.query_params.get(self.ordering_param)
+
+        if not params:
+            return self.get_default_ordering(view)
+
+        fields = [param.strip() for param in params.split(',')]
+        ordering = [filter for filter in fields if filter.lstrip('-') in self.allowed_custom_filters]
+
+        return ordering if ordering else self.get_default_ordering(view)
+
+    def filter_queryset(self, request, queryset, view):
+        """Class methods returns the ordered queryset.
+
+        Args:
+            request: The request.
+            queryset: The CourseRun queryset.
+            view: The CourseRunViewset.
+
+        Returns:
+            The ordered Queryset.
+        """
+        ordering = self.get_ordering(request, queryset, view)
+
+        return queryset.order_by(*ordering) if ordering else queryset.order_by('start')
 
 
 class ProgramFilter(FilterSetMixin, filters.FilterSet):

--- a/course_discovery/apps/api/v1/views/courses.py
+++ b/course_discovery/apps/api/v1/views/courses.py
@@ -144,6 +144,13 @@ class CourseViewSet(CompressedCacheResponseMixin, viewsets.ModelViewSet):
             if get_query_param(self.request, 'published_course_runs_only'):
                 course_runs = course_runs.filter(status=CourseRunStatus.Published)
 
+            # Apply an order to the course_runs by the parameter "course_runs_sort_by".
+            course_runs = filters.CourseRunOrderingFilter().filter_queryset(
+                self.request,
+                course_runs,
+                CourseRunViewSet,
+            )
+
             if get_query_param(self.request, 'include_deleted_programs'):
                 programs = Program.objects.all()
             else:

--- a/docs/custom_features.md
+++ b/docs/custom_features.md
@@ -1,0 +1,10 @@
+## Custom Features for Pearson Organization
+
+### Verify course run ordering in the /api/v1/courses API
+
+The team was assuming that the course run array in the /api/v1/courses/<course_key> API response is
+ordered by course start date. Making the respective discovery it was determined that the array of
+course runs in the resulting request is not implicitly ordered.
+
+Right now from `api/v1/courses/{key}` you can sort the courses descendingly using `api/v1/courses/{key}/?course_runs_sort_by=-start`
+and ascendingly by `api/v1/courses/{key}/?course_runs_sort_by=start`.


### PR DESCRIPTION
## Ticket

https://agile-jira.pearson.com/browse/PADV-487

## Description

We currently support custom changes to the Discovery service, so we need this ticket to apply these changes to the Olive version.

### Custom Feature

![Selection_085](https://github.com/Pearson-Advance/course-discovery/assets/30726391/b8d19f17-f0e0-4dd2-adca-bf1b4385344b)

## Changes Made

- [x] Cherry Pick custom changes from the branch [pearson-release/juniper.master](https://github.com/Pearson-Advance/course-discovery/commits/pearson-release/juniper.master)
- [x] Squash and Correct commit lint.

## How to test

- Install devstack.
- Run services.
- Verify the correct order of the ASC for the course_runs nested field in the api/v1/course/{key}.

## Reviewers

- [x] @Squirrel18
- [x] @alexjmpb 