### PR TITLE
PADV-2895 BE - Retrieve the courses associated to a particular Enterprise catalogue.

### DIFF
--- a/course_discovery/apps/enterprise_catalogs/apps.py
+++ b/course_discovery/apps/enterprise_catalogs/apps.py
@@ -1,0 +1,14 @@
+"""
+Configuration for the Enterprise Catalogs application.
+"""
+from django.apps import AppConfig
+
+
+class EnterpriseCatalogsConfig(AppConfig):
+    """
+    Django application configuration for Enterprise Catalogs.
+
+    This application retrieves course data associated with an Enterprise customer catalog.
+    """
+    default_auto_field = 'django.db.models.BigAutoField'
+    name = 'enterprise_catalogs'

--- a/course_discovery/apps/enterprise_catalogs/client.py
+++ b/course_discovery/apps/enterprise_catalogs/client.py
@@ -1,0 +1,66 @@
+"""
+Client for Enterprise Catalog API.
+"""
+import logging
+from urllib.parse import urljoin
+
+from django.conf import settings
+from requests.exceptions import RequestException
+
+from course_discovery.apps.enterprise_catalogs.exceptions import (
+    EnterpriseCatalogAPIError, EnterpriseCatalogNotFoundError,
+)
+from course_discovery.apps.enterprise_catalogs.strategies import ContentParserStrategyFactory
+
+logger = logging.getLogger(__name__)
+
+
+class EnterpriseCatalogClient:
+    """Client for Enterprise Catalog API."""
+
+    CATALOG_ENDPOINT_TEMPLATE = '/api/v1/enterprise-catalogs/{uuid}/get_content_metadata/'
+    PAGE_SIZE = 100
+    REQUEST_TIMEOUT = 30
+
+    def __init__(self, partner):
+        self.oauth_api_client = partner.oauth_api_client
+
+    def get_course_run_keys(self, catalog_uuid):
+        """Fetch course run keys for a catalog from Enterprise Catalog service."""
+        base_url = getattr(settings, 'ENTERPRISE_CATALOG_SERVICE_URL', '').rstrip('/')
+        url = urljoin(base_url, self.CATALOG_ENDPOINT_TEMPLATE.format(uuid=catalog_uuid))
+        params = {'page_size': self.PAGE_SIZE}
+
+        first_page = self._make_request(url, params)
+        all_results = list(first_page.get('results', []))
+        total_count = first_page.get('count', 0)
+        # Ceiling division to determine total pages from total count and page size.
+        total_pages = (total_count + self.PAGE_SIZE - 1) // self.PAGE_SIZE if total_count else 1
+
+        for page in range(2, total_pages + 1):
+            params['page'] = page
+            all_results.extend(self._make_request(url, params).get('results', []))
+
+        if not all_results:
+            logger.info('No results found for catalog %s.', catalog_uuid)
+            return ()
+
+        strategy = ContentParserStrategyFactory.get_strategy(all_results)
+        course_run_keys = strategy.extract_course_run_keys(all_results)
+
+        logger.info('Retrieved %s course runs for catalog %s.', len(course_run_keys), catalog_uuid)
+
+        return course_run_keys
+
+    def _make_request(self, url, params):
+        """Make a request to the Enterprise Catalog API with error handling."""
+        try:
+            response = self.oauth_api_client.get(url, params=params, timeout=self.REQUEST_TIMEOUT)
+            if response.status_code == 404:
+                raise EnterpriseCatalogNotFoundError()
+            if response.status_code >= 400:
+                raise EnterpriseCatalogAPIError()
+        except RequestException as exc:
+            raise EnterpriseCatalogAPIError() from exc
+
+        return response.json()

--- a/course_discovery/apps/enterprise_catalogs/exceptions.py
+++ b/course_discovery/apps/enterprise_catalogs/exceptions.py
@@ -1,0 +1,16 @@
+"""
+Custom exceptions for enterprise_catalogs app.
+"""
+
+
+class EnterpriseCatalogAPIError(Exception):
+    """Base exception for Enterprise Catalog API errors."""
+
+    message = 'Failed to fetch catalog content.'
+
+
+class EnterpriseCatalogNotFoundError(EnterpriseCatalogAPIError):
+    """Raised when catalog UUID is not found (404)."""
+
+    message = 'Catalog not found.'
+    status_code = 404

--- a/course_discovery/apps/enterprise_catalogs/serializers.py
+++ b/course_discovery/apps/enterprise_catalogs/serializers.py
@@ -1,0 +1,80 @@
+"""
+Serializers for enterprise_catalogs app.
+"""
+from urllib.parse import urlencode, urljoin
+
+from rest_framework import serializers
+
+from course_discovery.apps.course_metadata.models import CourseRun
+from course_discovery.apps.course_metadata.utils import get_course_run_estimated_hours
+
+
+class EnterpriseCatalogQueryParamsSerializer(serializers.Serializer):  # pylint: disable=abstract-method
+    """Serializer to validate query parameters."""
+    coupon_code = serializers.CharField(
+        required=True,
+        allow_blank=False,
+        max_length=128,
+        help_text='The coupon code to be used for enrollment.',
+    )
+
+    def validate_coupon_code(self, value):
+        """
+        Validate that coupon code contains only alphanumeric characters.
+
+        Although CharField validates type and length, it allows spaces and special characters.
+        Coupon codes for this integration must be strictly alphanumeric (no spaces or dashes),
+        so this validation ensures invalid codes are rejected before reaching the enrollment service.
+        """
+        if not value.isalnum():
+            raise serializers.ValidationError('Coupon code must contain only alphanumeric characters.')
+        return value
+
+
+class EnterpriseCatalogCourseSerializer(serializers.ModelSerializer):
+    """Serializer for CourseRun model in enterprise catalog context."""
+
+    title = serializers.CharField(source='course.title')
+    card_image_url = serializers.URLField(source='course.card_image_url')
+    topics = serializers.SerializerMethodField()
+    key = serializers.CharField()
+    pacing_type = serializers.CharField()
+    estimated_hours = serializers.SerializerMethodField()
+    enrollment_url = serializers.SerializerMethodField()
+
+    class Meta:
+        model = CourseRun
+        fields = (
+            'title',
+            'card_image_url',
+            'topics',
+            'key',
+            'pacing_type',
+            'estimated_hours',
+            'enrollment_url',
+        )
+
+    def get_topics(self, obj):
+        """Return list of topic names from the parent course."""
+        return tuple(tag.name for tag in obj.course.topics.all())
+
+    def get_estimated_hours(self, obj):
+        """Return estimated hours to complete the course run."""
+        return get_course_run_estimated_hours(obj)
+
+    def _get_sku(self, obj):
+        """Return SKU from the first available seat (internal use only)."""
+        first_seat = obj.seats.first()
+        return first_seat.sku if first_seat else None
+
+    def get_enrollment_url(self, obj):
+        """Return enrollment URL with coupon code and SKU."""
+        coupon_code = self.context.get('coupon_code')
+        partner = self.context.get('partner')
+        sku = self._get_sku(obj)
+
+        if not all([coupon_code, partner, getattr(partner, 'ecommerce_api_url', None), sku]):
+            return None
+
+        query_params = urlencode({'code': coupon_code, 'sku': sku})
+        return f"{urljoin(partner.ecommerce_api_url, '/coupons/redeem/')}?{query_params}"

--- a/course_discovery/apps/enterprise_catalogs/strategies.py
+++ b/course_discovery/apps/enterprise_catalogs/strategies.py
@@ -1,0 +1,73 @@
+"""
+Strategy pattern for parsing Enterprise Catalog API responses.
+
+The Enterprise Catalog API can return different content types based on the
+catalog's content filter configuration. This module provides strategies to
+extract course run keys from different response formats.
+"""
+from abc import ABC, abstractmethod
+
+
+class ContentParserStrategy(ABC):
+    """Abstract base class for content parsing strategies."""
+
+    content_type = None
+
+    @staticmethod
+    @abstractmethod
+    def extract_course_run_keys(results):
+        """Extract course run keys from the API results."""
+
+    @classmethod
+    def can_handle(cls, results):
+        """Determine if this strategy can handle the given results."""
+        if not results:
+            return False
+        return results[0].get('content_type') == cls.content_type
+
+
+class CourseRunContentStrategy(ContentParserStrategy):
+    """Strategy for content_type: courserun."""
+
+    content_type = 'courserun'
+
+    @staticmethod
+    def extract_course_run_keys(results):
+        return tuple(
+            item.get('key')
+            for item in results
+            if item.get('key')
+        )
+
+
+class CourseContentStrategy(ContentParserStrategy):
+    """Strategy for content_type: course."""
+
+    content_type = 'course'
+
+    @staticmethod
+    def extract_course_run_keys(results):
+        return tuple(
+            run.get('key')
+            for course in results
+            for run in course.get('course_runs', [])
+            if run.get('key')
+        )
+
+
+class ContentParserStrategyFactory:
+    """Factory for selecting the appropriate content parser strategy."""
+
+    _strategies = (
+        CourseRunContentStrategy,
+        CourseContentStrategy,
+    )
+
+    @staticmethod
+    def get_strategy(results):
+        for strategy_class in ContentParserStrategyFactory._strategies:
+            if strategy_class.can_handle(results):
+                return strategy_class
+
+        content_type = results[0].get('content_type', 'unknown') if results else 'unknown'
+        raise ValueError(f'No strategy found for content_type: {content_type}.')

--- a/course_discovery/apps/enterprise_catalogs/urls.py
+++ b/course_discovery/apps/enterprise_catalogs/urls.py
@@ -1,0 +1,17 @@
+"""
+URL configuration for enterprise_catalogs app.
+"""
+
+from django.urls import path
+
+from course_discovery.apps.enterprise_catalogs import views
+
+app_name = 'enterprise_catalogs'
+
+urlpatterns = [
+    path(
+        '<uuid:catalog_uuid>/courses/',
+        views.EnterpriseCatalogCoursesView.as_view(),
+        name='enterprise-catalog-courses',
+    ),
+]

--- a/course_discovery/apps/enterprise_catalogs/views.py
+++ b/course_discovery/apps/enterprise_catalogs/views.py
@@ -24,8 +24,10 @@ logger = logging.getLogger(__name__)
 
 class EnterpriseCatalogCoursesView(ListAPIView):
     """
-    This view supports both authenticated and anonymous requests
-    as it is consumed by the MFE.
+    API view to list course runs from an Enterprise Catalog.
+
+    Uses AllowAny permission since authentication is not required to access this endpoint.
+    This allows the MFE to fetch catalog data without requiring user login.
     """
 
     permission_classes = (AllowAny,)

--- a/course_discovery/apps/enterprise_catalogs/views.py
+++ b/course_discovery/apps/enterprise_catalogs/views.py
@@ -1,0 +1,89 @@
+"""
+Views for enterprise_catalogs app.
+"""
+import logging
+
+from rest_framework import status
+from rest_framework.generics import ListAPIView
+from rest_framework.pagination import PageNumberPagination
+from rest_framework.permissions import AllowAny
+from rest_framework.response import Response
+from rest_framework.throttling import AnonRateThrottle, UserRateThrottle
+
+from course_discovery.apps.course_metadata.models import CourseRun
+from course_discovery.apps.enterprise_catalogs.client import EnterpriseCatalogClient
+from course_discovery.apps.enterprise_catalogs.exceptions import (
+    EnterpriseCatalogAPIError, EnterpriseCatalogNotFoundError,
+)
+from course_discovery.apps.enterprise_catalogs.serializers import (
+    EnterpriseCatalogCourseSerializer, EnterpriseCatalogQueryParamsSerializer,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class EnterpriseCatalogCoursesView(ListAPIView):
+    """
+    This view supports both authenticated and anonymous requests
+    as it is consumed by the MFE.
+    """
+
+    permission_classes = (AllowAny,)
+    throttle_classes = (AnonRateThrottle, UserRateThrottle,)
+    serializer_class = EnterpriseCatalogCourseSerializer
+    pagination_class = PageNumberPagination
+
+    def get(self, request, *args, **kwargs):
+        """Handle GET request with custom error handling."""
+        query_params = EnterpriseCatalogQueryParamsSerializer(data=request.query_params)
+        query_params.is_valid(raise_exception=True)
+
+        try:
+            return super().get(request, *args, **kwargs)
+        except EnterpriseCatalogNotFoundError as exc:
+            return Response(
+                {'error': exc.message},
+                status=status.HTTP_404_NOT_FOUND,
+            )
+        except EnterpriseCatalogAPIError as exc:
+            return Response(
+                {'error': exc.message},
+                status=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            )
+
+    def get_queryset(self):
+        """Fetch courses from Discovery database based on Enterprise Catalog keys."""
+        catalog_uuid = str(self.kwargs.get('catalog_uuid'))
+        course_run_keys = EnterpriseCatalogClient(self.request.site.partner).get_course_run_keys(
+            catalog_uuid,
+        )
+
+        queryset = CourseRun.objects.filter(
+            key__in=course_run_keys,
+            seats__sku__isnull=False,
+        ).select_related(
+            'course',
+        ).prefetch_related(
+            'course__topics',
+            'seats',
+        )
+
+        results = list(queryset)
+        found_keys = {course_run.key for course_run in results}
+        excluded_keys = set(course_run_keys) - found_keys
+
+        if excluded_keys:
+            logger.warning(
+                'Course runs excluded from catalog %s due to missing SKU: %s',
+                catalog_uuid,
+                excluded_keys,
+            )
+
+        return results
+
+    def get_serializer_context(self):
+        """Add validated coupon code and partner to serializer context."""
+        context = super().get_serializer_context()
+        context['coupon_code'] = self.request.query_params.get('coupon_code')
+        context['partner'] = self.request.site.partner
+        return context

--- a/course_discovery/settings/base.py
+++ b/course_discovery/settings/base.py
@@ -416,6 +416,9 @@ REST_FRAMEWORK = {
     ),
     'DEFAULT_THROTTLE_RATES': {
         'user': '100/hour',
+        # Rate limit for anonymous (unauthenticated) requests, identified by IP address.
+        # Used by AnonRateThrottle in views with AllowAny permission.
+        'anon': '100/hour',
     },
     'DEFAULT_SCHEMA_CLASS': 'rest_framework.schemas.coreapi.AutoSchema'
 }
@@ -686,3 +689,8 @@ LMS_API_URLS = {
     'blocks': 'api/courses/v1/blocks/',
     'block_metadata': 'api/courses/v1/block_metadata/',
 }
+
+# ENTERPRISE CONFIGURATION
+# Base URL for the Enterprise Catalog service.
+# Used to fetch catalog content and course run data for enterprise customers.
+ENTERPRISE_CATALOG_SERVICE_URL = 'http://localhost:18160'

--- a/course_discovery/urls.py
+++ b/course_discovery/urls.py
@@ -48,6 +48,7 @@ urlpatterns = oauth2_urlpatterns + [
     path('api-auth/', include((oauth2_urlpatterns, 'rest_framework'))),
     path('api-docs/', schema_view.with_ui('swagger', cache_timeout=0), name='api_docs'),
     path('auto_auth/', core_views.AutoAuth.as_view(), name='auto_auth'),
+    path('enterprise_catalogs/', include('course_discovery.apps.enterprise_catalogs.urls', namespace='enterprise_catalogs')),
     path('health/', core_views.health, name='health'),
     path('', QueryPreviewView.as_view()),
     path('publisher/', include('course_discovery.apps.publisher.urls', namespace='publisher')),


### PR DESCRIPTION
## Description

This PR adds a new enterprise catalogs functionality to the course-discovery service. It implements a new Django app that enables backend-to-backend communication with the enterprise-catalog service to retrieve and synchronize course catalogs for enterprise customers. The implementation includes a client for API communication, automatic pagination handling, and robust error management.

## Type of Change
- [x] Add new enterprise_catalogs Django app
- [x] Implement EnterpriseCatalogClient for BE-to-BE API communication with OAuth2
- [x] Add catalog retrieval endpoint with automatic pagination
- [x] Implement custom exception handling for 404 and API errors
- [x] Add comprehensive logging for debugging and monitoring

## How to Test

### Prerequisites
1. Ensure the enterprise-catalog service is running and accessible
2. Set `ENTERPRISE_CATALOG_SERVICE_URL` in your Django settings
3. Ensure OAuth2 credentials are configured for the partner

### Testing Steps

1. **Get a valid catalog UUID** (with dashes):
   ```bash
   # UUID format: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
   # Example: 1da5d63b-c764-4d3a-8df4-da1c092dc8ef

Test the endpoint:

GET /enterprise_catalogs/<uuid:catalog_uuid>/courses/
## Reviewers

- [ ] @Squirrel18 