### PR TITLE
PADV-3003 BE - Add caching for Enterprise Catalog course metadata

### DIFF
--- a/course_discovery/apps/enterprise_catalogs/client.py
+++ b/course_discovery/apps/enterprise_catalogs/client.py
@@ -5,6 +5,7 @@ import logging
 from urllib.parse import urljoin
 
 from django.conf import settings
+from django.core.cache import cache
 from requests.exceptions import RequestException
 
 from course_discovery.apps.enterprise_catalogs.exceptions import (
@@ -21,12 +22,26 @@ class EnterpriseCatalogClient:
     CATALOG_ENDPOINT_TEMPLATE = '/api/v1/enterprise-catalogs/{uuid}/get_content_metadata/'
     PAGE_SIZE = 100
     REQUEST_TIMEOUT = 30
+    CACHE_KEY_TEMPLATE = '{module}.courses.{uuid}.v1'
 
     def __init__(self, partner):
         self.oauth_api_client = partner.oauth_api_client
 
+    def _build_cache_key(self, catalog_uuid):
+        """Build versioned cache key for catalog."""
+        return self.CACHE_KEY_TEMPLATE.format(module=__name__, uuid=catalog_uuid)
+
     def get_course_run_keys(self, catalog_uuid):
         """Fetch course run keys for a catalog from Enterprise Catalog service."""
+        cache_key = self._build_cache_key(catalog_uuid)
+        cached_data = cache.get(cache_key)
+
+        if cached_data:
+            logger.info('Cache HIT for catalog %s.', catalog_uuid)
+            return cached_data
+
+        logger.info('Cache MISS for catalog %s - fetching from API.', catalog_uuid)
+
         base_url = getattr(settings, 'ENTERPRISE_CATALOG_SERVICE_URL', '').rstrip('/')
         url = urljoin(base_url, self.CATALOG_ENDPOINT_TEMPLATE.format(uuid=catalog_uuid))
         params = {'page_size': self.PAGE_SIZE}
@@ -48,7 +63,10 @@ class EnterpriseCatalogClient:
         strategy = ContentParserStrategyFactory.get_strategy(all_results)
         course_run_keys = strategy.extract_course_run_keys(all_results)
 
-        logger.info('Retrieved %s course runs for catalog %s.', len(course_run_keys), catalog_uuid)
+        timeout = getattr(settings, 'ENTERPRISE_CATALOG_CACHE_TIMEOUT', 3600)
+        cache.set(cache_key, course_run_keys, timeout=timeout)
+
+        logger.info('Retrieved and cached %s course runs for catalog %s (TTL: %ss).', len(course_run_keys), catalog_uuid, timeout)
 
         return course_run_keys
 

--- a/course_discovery/settings/base.py
+++ b/course_discovery/settings/base.py
@@ -694,3 +694,7 @@ LMS_API_URLS = {
 # Base URL for the Enterprise Catalog service.
 # Used to fetch catalog content and course run data for enterprise customers.
 ENTERPRISE_CATALOG_SERVICE_URL = 'http://localhost:18160'
+
+# Cache timeout for Enterprise Catalog API responses (in seconds).
+# Default: 3600 seconds (1 hour)
+ENTERPRISE_CATALOG_CACHE_TIMEOUT = 3600


### PR DESCRIPTION
## Description
This PR implements a caching mechanism for Enterprise Catalog course metadata in the Discovery service.

Currently, every request to /enterprise_catalogs/{catalog_uuid}/courses/ triggers a call to the Enterprise Catalog service endpoint /api/v1/enterprise-catalogs/{uuid}/get_content_metadata/, including pagination handling. By adding a cache layer using Django's cache framework (Memcached), repeated requests for the same catalog will be served from cache instead of making redundant API calls, reducing external API calls and improving response times.

## Type of Change
Add caching logic in EnterpriseCatalogClient.get_course_run_keys() method
Implement versioned cache keys with format enterprise_catalog_courses_{catalog_uuid}_v1
Add configurable cache TTL setting ENTERPRISE_CATALOG_CACHE_TIMEOUT (default: 1 hour)
Include cache HIT/MISS logging for monitoring and debugging

## How to Test
### Prerequisites
Ensure the Discovery service is running
Verify that Memcached is configured and running (already available in devstack)
Have a valid Enterprise Catalog UUID with associated courses
Testing Steps
Cache Miss - First Request: Make a request to fetch courses for a catalog:


GET /enterprise_catalogs/{catalog_uuid}/courses/
Check the logs for: Cache MISS for catalog {uuid} - fetching from API

Cache Hit - Subsequent Requests: Make the same request again within the TTL period.
Check the logs for: Cache HIT for catalog {uuid}
Verify that no external API call is made.

Cache Expiration: Wait for the TTL to expire (or modify ENTERPRISE_CATALOG_CACHE_TIMEOUT to a shorter value for testing), then make another request.
Verify that a cache MISS occurs and fresh data is fetched.

Validate Response: Ensure the returned course data is consistent between cached and non-cached responses.

## Reviewers

- [ ] @Squirrel18 