### PR TITLE
PADV-2896 BE - Add filterset to discovery API

### DIFF
--- a/course_discovery/apps/enterprise_catalogs/filters.py
+++ b/course_discovery/apps/enterprise_catalogs/filters.py
@@ -1,0 +1,17 @@
+"""
+Filters for enterprise_catalogs app.
+"""
+from django_filters import rest_framework as filters
+
+from course_discovery.apps.course_metadata.models import CourseRun
+
+
+class EnterpriseCatalogCourseRunFilter(filters.FilterSet):
+    """FilterSet for Enterprise Catalog course runs."""
+
+    search = filters.CharFilter(field_name='course__title', lookup_expr='icontains')
+    topics = filters.BaseInFilter(field_name='course__topics__name', distinct=True)
+
+    class Meta:
+        model = CourseRun
+        fields = ('search', 'topics',)

--- a/course_discovery/apps/enterprise_catalogs/views.py
+++ b/course_discovery/apps/enterprise_catalogs/views.py
@@ -3,6 +3,7 @@ Views for enterprise_catalogs app.
 """
 import logging
 
+from django_filters.rest_framework import DjangoFilterBackend
 from rest_framework import status
 from rest_framework.generics import ListAPIView
 from rest_framework.pagination import PageNumberPagination
@@ -15,6 +16,7 @@ from course_discovery.apps.enterprise_catalogs.client import EnterpriseCatalogCl
 from course_discovery.apps.enterprise_catalogs.exceptions import (
     EnterpriseCatalogAPIError, EnterpriseCatalogNotFoundError,
 )
+from course_discovery.apps.enterprise_catalogs.filters import EnterpriseCatalogCourseRunFilter
 from course_discovery.apps.enterprise_catalogs.serializers import (
     EnterpriseCatalogCourseSerializer, EnterpriseCatalogQueryParamsSerializer,
 )
@@ -34,6 +36,8 @@ class EnterpriseCatalogCoursesView(ListAPIView):
     throttle_classes = (AnonRateThrottle, UserRateThrottle,)
     serializer_class = EnterpriseCatalogCourseSerializer
     pagination_class = PageNumberPagination
+    filter_backends = (DjangoFilterBackend,)
+    filterset_class = EnterpriseCatalogCourseRunFilter
 
     def get(self, request, *args, **kwargs):
         """Handle GET request with custom error handling."""
@@ -70,18 +74,15 @@ class EnterpriseCatalogCoursesView(ListAPIView):
             'seats',
         )
 
-        results = list(queryset)
-        found_keys = {course_run.key for course_run in results}
-        excluded_keys = set(course_run_keys) - found_keys
-
+        excluded_keys = set(course_run_keys) - set(queryset.values_list('key', flat=True))
         if excluded_keys:
             logger.warning(
-                'Course runs excluded from catalog %s due to missing SKU: %s',
+                'Course runs excluded from catalog %s due to missing SKU: %s.',
                 catalog_uuid,
                 excluded_keys,
             )
 
-        return results
+        return queryset
 
     def get_serializer_context(self):
         """Add validated coupon code and partner to serializer context."""


### PR DESCRIPTION
## Description
This PR adds filtering and search capabilities to the Enterprise Catalog courses endpoint (GET /enterprise_catalogs/{catalog_uuid}/courses/).

Users can now refine the list of courses returned by the API using:

Search text: Filter courses by title using partial text matching
Topics: Filter by one or more topic names (comma-separated)
All filters are optional and can be combined. Results remain scoped to the specified Enterprise Catalog UUID and maintain pagination support.

## Type of Change
Add _apply_search_filter() method to filter by course title (icontains)
Add _apply_topics_filter() method to filter by topic names using OR logic
Query parameters: ?search=<text>&topics=<topic1>,<topic2>&page=<number>

## How to Test
Prerequisites
Discovery service running
Valid Enterprise Catalog UUID with associated courses
Courses with topics assigned

### Testing Steps
1. No filters (baseline):

GET /enterprise_catalogs/{catalog_uuid}/courses/?coupon_code=TESTCODE
Verify all courses in the catalog are returned.

2. Search filter:
GET /enterprise_catalogs/{catalog_uuid}/courses/?coupon_code=TESTCODE&search=python
Verify only courses with "python" in the title are returned.

4. Topics filter:
GET /enterprise_catalogs/{catalog_uuid}/courses/?coupon_code=TESTCODE&topics=programming,data
Verify only courses with "programming" OR "data" topics are returned.

5. Combined filters:
GET /enterprise_catalogs/{catalog_uuid}/courses/?coupon_code=TESTCODE&search=intro&topics=python
Verify filters are applied together (AND between search and topics).

6. Pagination with filters:
GET /enterprise_catalogs/{catalog_uuid}/courses/?coupon_code=TESTCODE&search=course&page=2

Verify pagination works correctly on filtered results.

## Reviewers

- [ ] @Squirrel18 