### PR TITLE
PADV-3029 BE -Extend EnterpriseCatalogCoursesView to support Single Course RETRIEVE

### DIFF
--- a/course_discovery/apps/enterprise_catalogs/exceptions.py
+++ b/course_discovery/apps/enterprise_catalogs/exceptions.py
@@ -14,3 +14,10 @@ class EnterpriseCatalogNotFoundError(EnterpriseCatalogAPIError):
 
     message = 'Catalog not found.'
     status_code = 404
+
+
+class EnterpriseCatalogCourseNotFoundError(EnterpriseCatalogAPIError):
+    """Raised when course is not found in the catalog (404)."""
+
+    message = 'Course not found in catalog.'
+    status_code = 404

--- a/course_discovery/apps/enterprise_catalogs/serializers.py
+++ b/course_discovery/apps/enterprise_catalogs/serializers.py
@@ -1,12 +1,17 @@
 """
 Serializers for enterprise_catalogs app.
 """
+import json
+import logging
 from urllib.parse import urlencode, urljoin
 
 from rest_framework import serializers
 
 from course_discovery.apps.course_metadata.models import CourseRun
 from course_discovery.apps.course_metadata.utils import get_course_run_estimated_hours
+
+logger = logging.getLogger(__name__)
+COUPON_REDEEM_PATH = '/coupons/redeem/'
 
 
 class EnterpriseCatalogQueryParamsSerializer(serializers.Serializer):  # pylint: disable=abstract-method
@@ -31,7 +36,28 @@ class EnterpriseCatalogQueryParamsSerializer(serializers.Serializer):  # pylint:
         return value
 
 
-class EnterpriseCatalogCourseSerializer(serializers.ModelSerializer):
+class EnterpriseCatalogSerializerMixin:
+    """Mixin with shared logic for enterprise catalog serializers."""
+
+    def _get_sku(self, obj):
+        """Return SKU from the first available seat."""
+        first_seat = obj.seats.first()
+        return first_seat.sku if first_seat else None
+
+    def get_enrollment_url(self, obj):
+        """Return enrollment URL with coupon code and SKU."""
+        coupon_code = self.context.get('coupon_code')
+        partner = self.context.get('partner')
+        sku = self._get_sku(obj)
+
+        if not all([coupon_code, partner, getattr(partner, 'ecommerce_api_url', None), sku]):
+            return None
+
+        query_params = urlencode({'code': coupon_code, 'sku': sku})
+        return f"{urljoin(partner.ecommerce_api_url, COUPON_REDEEM_PATH)}?{query_params}"
+
+
+class EnterpriseCatalogCourseSerializer(EnterpriseCatalogSerializerMixin, serializers.ModelSerializer):
     """Serializer for CourseRun model in enterprise catalog context."""
 
     title = serializers.CharField(source='course.title')
@@ -62,19 +88,75 @@ class EnterpriseCatalogCourseSerializer(serializers.ModelSerializer):
         """Return estimated hours to complete the course run."""
         return get_course_run_estimated_hours(obj)
 
-    def _get_sku(self, obj):
-        """Return SKU from the first available seat (internal use only)."""
-        first_seat = obj.seats.first()
-        return first_seat.sku if first_seat else None
 
-    def get_enrollment_url(self, obj):
-        """Return enrollment URL with coupon code and SKU."""
-        coupon_code = self.context.get('coupon_code')
-        partner = self.context.get('partner')
-        sku = self._get_sku(obj)
+class EnterpriseCatalogCourseDetailSerializer(EnterpriseCatalogSerializerMixin, serializers.ModelSerializer):
+    """Serializer for individual CourseRun detail in enterprise catalog context."""
 
-        if not all([coupon_code, partner, getattr(partner, 'ecommerce_api_url', None), sku]):
-            return None
+    _extra_description_cache = None
+    title = serializers.CharField(source='course.title')
+    overview = serializers.CharField(source='course.full_description', allow_null=True)
+    outline = serializers.CharField(source='course.syllabus_raw', allow_null=True)
+    prerequisites = serializers.CharField(source='course.prerequisites_raw', allow_null=True)
+    learning_objectives = serializers.CharField(source='course.outcome', allow_null=True)
+    vendor = serializers.SerializerMethodField()
+    author = serializers.SerializerMethodField()
+    included_materials = serializers.SerializerMethodField()
+    duration = serializers.SerializerMethodField()
+    target_audience = serializers.SerializerMethodField()
+    enrollment_url = serializers.SerializerMethodField()
 
-        query_params = urlencode({'code': coupon_code, 'sku': sku})
-        return f"{urljoin(partner.ecommerce_api_url, '/coupons/redeem/')}?{query_params}"
+    class Meta:
+        model = CourseRun
+        fields = (
+            'title',
+            'overview',
+            'outline',
+            'prerequisites',
+            'learning_objectives',
+            'vendor',
+            'author',
+            'included_materials',
+            'duration',
+            'target_audience',
+            'enrollment_url',
+        )
+
+    def _get_extra_description_data(self, obj):
+        """Parse extra_description JSON once per object and cache the result."""
+        if self._extra_description_cache is not None:
+            return self._extra_description_cache
+
+        description = getattr(obj.course.extra_description, 'description', None)
+        if not description:
+            return {}
+
+        try:
+            self._extra_description_cache = json.loads(description)
+        except (json.JSONDecodeError, TypeError):
+            logger.exception(
+                'Failed to parse extra_description JSON for course run %s.', obj,
+            )
+            self._extra_description_cache = {}
+
+        return self._extra_description_cache
+
+    def get_vendor(self, obj):
+        """Return vendor name from extra_description JSON."""
+        return self._get_extra_description_data(obj).get('vendor')
+
+    def get_author(self, obj):
+        """Return author from extra_description JSON."""
+        return self._get_extra_description_data(obj).get('author')
+
+    def get_included_materials(self, obj):
+        """Return included materials list from extra_description JSON."""
+        return self._get_extra_description_data(obj).get('included_materials')
+
+    def get_duration(self, obj):
+        """Return duration from extra_description JSON."""
+        return self._get_extra_description_data(obj).get('duration')
+
+    def get_target_audience(self, obj):
+        """Return target audience from extra_description JSON."""
+        return self._get_extra_description_data(obj).get('target_audience')
+

--- a/course_discovery/apps/enterprise_catalogs/urls.py
+++ b/course_discovery/apps/enterprise_catalogs/urls.py
@@ -2,16 +2,16 @@
 URL configuration for enterprise_catalogs app.
 """
 
-from django.urls import path
+from django.urls import include, path
+from rest_framework.routers import SimpleRouter
 
-from course_discovery.apps.enterprise_catalogs import views
+from course_discovery.apps.enterprise_catalogs.views import EnterpriseCatalogCoursesViewSet
 
 app_name = 'enterprise_catalogs'
 
+router = SimpleRouter()
+router.register('courses', EnterpriseCatalogCoursesViewSet, basename='enterprise-catalog-courses')
+
 urlpatterns = [
-    path(
-        '<uuid:catalog_uuid>/courses/',
-        views.EnterpriseCatalogCoursesView.as_view(),
-        name='enterprise-catalog-courses',
-    ),
+    path('<uuid:catalog_uuid>/', include(router.urls)),
 ]

--- a/course_discovery/apps/enterprise_catalogs/views.py
+++ b/course_discovery/apps/enterprise_catalogs/views.py
@@ -4,8 +4,11 @@ Views for enterprise_catalogs app.
 import logging
 
 from django_filters.rest_framework import DjangoFilterBackend
+from opaque_keys import InvalidKeyError
+from opaque_keys.edx.keys import CourseKey
 from rest_framework import status
-from rest_framework.generics import ListAPIView
+from rest_framework.mixins import ListModelMixin, RetrieveModelMixin
+from rest_framework.viewsets import GenericViewSet
 from rest_framework.pagination import PageNumberPagination
 from rest_framework.permissions import AllowAny
 from rest_framework.response import Response
@@ -14,19 +17,26 @@ from rest_framework.throttling import AnonRateThrottle, UserRateThrottle
 from course_discovery.apps.course_metadata.models import CourseRun
 from course_discovery.apps.enterprise_catalogs.client import EnterpriseCatalogClient
 from course_discovery.apps.enterprise_catalogs.exceptions import (
-    EnterpriseCatalogAPIError, EnterpriseCatalogNotFoundError,
+    EnterpriseCatalogAPIError, EnterpriseCatalogCourseNotFoundError, EnterpriseCatalogNotFoundError,
 )
 from course_discovery.apps.enterprise_catalogs.filters import EnterpriseCatalogCourseRunFilter
 from course_discovery.apps.enterprise_catalogs.serializers import (
-    EnterpriseCatalogCourseSerializer, EnterpriseCatalogQueryParamsSerializer,
+    EnterpriseCatalogCourseDetailSerializer, EnterpriseCatalogCourseSerializer, EnterpriseCatalogQueryParamsSerializer,
 )
 
 logger = logging.getLogger(__name__)
 
 
-class EnterpriseCatalogCoursesView(ListAPIView):
+class EnterpriseCatalogCoursesViewSet(
+    ListModelMixin,
+    RetrieveModelMixin,
+    GenericViewSet,
+):
     """
-    API view to list course runs from an Enterprise Catalog.
+    ViewSet to list and retrieve course runs from an Enterprise Catalog.
+
+    - LIST: GET /enterprise_catalogs/{catalog_uuid}/courses/
+    - RETRIEVE: GET /enterprise_catalogs/{catalog_uuid}/courses/{course_run_key}/
 
     Uses AllowAny permission since authentication is not required to access this endpoint.
     This allows the MFE to fetch catalog data without requiring user login.
@@ -38,24 +48,19 @@ class EnterpriseCatalogCoursesView(ListAPIView):
     pagination_class = PageNumberPagination
     filter_backends = (DjangoFilterBackend,)
     filterset_class = EnterpriseCatalogCourseRunFilter
+    lookup_url_kwarg = 'course_run_key'
 
-    def get(self, request, *args, **kwargs):
-        """Handle GET request with custom error handling."""
+    def get_serializer_class(self):
+        """Return detail serializer for retrieve, list serializer otherwise."""
+        if self.action == 'retrieve':
+            return EnterpriseCatalogCourseDetailSerializer
+        return EnterpriseCatalogCourseSerializer
+
+    def initial(self, request, *args, **kwargs):
+        """Validate query params before any action."""
+        super().initial(request, *args, **kwargs)
         query_params = EnterpriseCatalogQueryParamsSerializer(data=request.query_params)
         query_params.is_valid(raise_exception=True)
-
-        try:
-            return super().get(request, *args, **kwargs)
-        except EnterpriseCatalogNotFoundError as exc:
-            return Response(
-                {'error': exc.message},
-                status=status.HTTP_404_NOT_FOUND,
-            )
-        except EnterpriseCatalogAPIError as exc:
-            return Response(
-                {'error': exc.message},
-                status=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            )
 
     def get_queryset(self):
         """Fetch courses from Discovery database based on Enterprise Catalog keys."""
@@ -84,9 +89,55 @@ class EnterpriseCatalogCoursesView(ListAPIView):
 
         return queryset
 
+    def get_object(self):
+        """Get single course run, validating membership in catalog."""
+        catalog_uuid = str(self.kwargs.get('catalog_uuid'))
+        course_run_key = self.kwargs.get('course_run_key')
+
+        if not self._is_valid_course_run_key(course_run_key):
+            logger.warning('Invalid course_run_key format received: %s.', course_run_key)
+            raise EnterpriseCatalogCourseNotFoundError()
+
+        catalog_keys = EnterpriseCatalogClient(self.request.site.partner).get_course_run_keys(catalog_uuid)
+        if course_run_key not in catalog_keys:
+            raise EnterpriseCatalogCourseNotFoundError()
+
+        try:
+            return CourseRun.objects.select_related(
+                'course',
+                'course__extra_description',
+            ).prefetch_related(
+                'seats',
+            ).get(key=course_run_key)
+        except CourseRun.DoesNotExist:
+            raise EnterpriseCatalogCourseNotFoundError()
+
     def get_serializer_context(self):
         """Add validated coupon code and partner to serializer context."""
         context = super().get_serializer_context()
         context['coupon_code'] = self.request.query_params.get('coupon_code')
         context['partner'] = self.request.site.partner
         return context
+
+    def handle_exception(self, exc):
+        """Handle catalog-specific exceptions."""
+        if isinstance(exc, (EnterpriseCatalogNotFoundError, EnterpriseCatalogCourseNotFoundError)):
+            return Response(
+                {'error': exc.message},
+                status=status.HTTP_404_NOT_FOUND,
+            )
+        if isinstance(exc, EnterpriseCatalogAPIError):
+            return Response(
+                {'error': exc.message},
+                status=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            )
+        return super().handle_exception(exc)
+
+    @staticmethod
+    def _is_valid_course_run_key(course_run_key):
+        """Return True if course_run_key is a valid CourseKey string."""
+        try:
+            CourseKey.from_string(course_run_key)
+            return True
+        except InvalidKeyError:
+            return False


### PR DESCRIPTION
# Description

This PR extends the EnterpriseCatalogCoursesView to support single course RETRIEVE alongside the existing LIST operation.

The MFE needs to fetch details for an individual course within an enterprise catalog. The view now handles both operations through a unified endpoint, validating that the requested course belongs to the catalog before returning its details.

## Key changes:
- RETRIEVE endpoint: GET /enterprise_catalogs/{catalog_uuid}/courses/{course_run_key}/ returns detailed course information
- Detail serializer: New EnterpriseCatalogCourseDetailSerializer exposes vendor, topics, outline, prerequisites, learning_objectives, and extra_description (parsed from JSON)
- Shared mixin: Extracted EnterpriseCatalogBaseMixin to deduplicate get_topics, get_enrollment_url, get_estimated_hours across list and detail serializers

## How to Test
### Prerequisites

Discovery service running
Valid Enterprise Catalog UUID with associated courses
Course with extra_description populated (vendor, author, included_materials, target_audience)

## Testing Steps

1. RETRIEVE single course:
```
curl --request GET --url 'http://localhost/enterprise_catalogs/{catalog_uuid}/courses/{course_run_key}/?coupon_code=TESTCODE'
```
Verify response includes: 'title', 'overview', 'outline', 'prerequisites', 'learning_objectives', 'vendor', 'author', 'included_materials', 'duration', 'target_audience', 'enrollment_url'.

2. RETRIEVE course not in catalog:

GET /enterprise_catalogs/{catalog_uuid}/courses/{invalid_key}/?coupon_code=TESTCODE
Verify 404 with "Course not found in catalog.".

3. RETRIEVE with invalid catalog UUID:

GET /enterprise_catalogs/{invalid_uuid}/courses/{course_run_key}/?coupon_code=TESTCODE
Verify 404 with "Catalog not found.".

4. LIST with filters still works:

GET /enterprise_catalogs/{catalog_uuid}/courses/?coupon_code=TESTCODE&search=python&topics=ai

Verify filters apply correctly on list operation.

## Reviewers

- [ ] @Squirrel18 