### PR TITLE
BE - API Discovery - Fix SKU resolution and improve Enterprise Catalog error logging

### DIFF
--- a/course_discovery/apps/enterprise_catalogs/client.py
+++ b/course_discovery/apps/enterprise_catalogs/client.py
@@ -77,8 +77,17 @@ class EnterpriseCatalogClient:
             if response.status_code == 404:
                 raise EnterpriseCatalogNotFoundError()
             if response.status_code >= 400:
+                try:
+                    detail = response.json()
+                except ValueError:
+                    detail = response.text
+                logger.error(
+                    'Enterprise Catalog returned %s for %s: %s',
+                    response.status_code, url, detail,
+                )
                 raise EnterpriseCatalogAPIError()
         except RequestException as exc:
+            logger.error('Enterprise Catalog request failed for %s: %s', url, exc)
             raise EnterpriseCatalogAPIError() from exc
 
         return response.json()

--- a/course_discovery/apps/enterprise_catalogs/serializers.py
+++ b/course_discovery/apps/enterprise_catalogs/serializers.py
@@ -40,9 +40,9 @@ class EnterpriseCatalogSerializerMixin:
     """Mixin with shared logic for enterprise catalog serializers."""
 
     def _get_sku(self, obj):
-        """Return SKU from the first available seat."""
-        first_seat = obj.seats.first()
-        return first_seat.sku if first_seat else None
+        """Return SKU from the professional seat."""
+        seat = obj.seats.filter(type__slug='professional').first()
+        return seat.sku if seat else None
 
     def get_enrollment_url(self, obj):
         """Return enrollment URL with coupon code and SKU."""

--- a/course_discovery/apps/enterprise_catalogs/views.py
+++ b/course_discovery/apps/enterprise_catalogs/views.py
@@ -72,6 +72,7 @@ class EnterpriseCatalogCoursesViewSet(
         queryset = CourseRun.objects.filter(
             key__in=course_run_keys,
             seats__sku__isnull=False,
+            seats__type__slug='professional',
         ).select_related(
             'course',
         ).prefetch_related(
@@ -108,7 +109,7 @@ class EnterpriseCatalogCoursesViewSet(
                 'course__extra_description',
             ).prefetch_related(
                 'seats',
-            ).get(key=course_run_key)
+            ).get(key=course_run_key, seats__sku__isnull=False, seats__type__slug='professional')
         except CourseRun.DoesNotExist:
             raise EnterpriseCatalogCourseNotFoundError()
 


### PR DESCRIPTION
# Description
This PR fixes two bugs identified in the EnterpriseCatalogCoursesView: incorrect SKU resolution and opaque error logging when the Enterprise Catalog API fails.

## Key changes

**SKU resolution fix (serializers.py, views.py)**

_get_sku now explicitly filters by type__slug='professional' instead of blindly taking seats.first(), ensuring the enrollment URL is built from the correct seat type.
get_queryset and get_object now filter CourseRun by seats__type__slug='professional' and seats__sku__isnull=False, excluding courses without an enrollable professional seat from both list and detail endpoints.

**Error logging (client.py, exceptions.py)**

_make_request now logs HTTP errors (status ≥ 400) including status code, URL, and response body before raising, and logs connection errors (RequestException) including URL and exception details.

User-facing error responses remain generic ("Failed to fetch catalog content.").

## How to Test
### Prerequisites

- Discovery service running.
- Enterprise Catalog with at least one CourseRun having a professional seat with valid SKU.
- A second seat with null SKU on the same CourseRun to verify SKU resolution.
- 
## Testing Steps

SKU resolution — LIST:

GET /enterprise_catalogs/{catalog_uuid}/courses/?coupon_code=TESTCODE
Verify enrollment_url is not null for courses with a professional seat.

SKU resolution — RETRIEVE:

GET /enterprise_catalogs/{catalog_uuid}/courses/{course_run_key}/?coupon_code=TESTCODE
Verify enrollment_url uses the SKU from the professional seat.

Courses without professional seat excluded:

GET /enterprise_catalogs/{catalog_uuid}/courses/?coupon_code=TESTCODE
Verify CourseRun without a professional seat does not appear in the list.

Error logging — HTTP error:
Temporarily misconfigure ENTERPRISE_CATALOG_SERVICE_URL to a valid but unauthorized endpoint.
Verify Discovery logs show status code, URL, and response body. User receives {"error": "Failed to fetch catalog content."}.

Error logging — connection error:
Set ENTERPRISE_CATALOG_SERVICE_URL to an unreachable host.
Verify Discovery logs show URL and connection error details.

## Reviewers

- [ ] @kuipumu 