### PR TITLE
PADV-3208 BE -API Discovery - Add card_image_url to catalog course detail endpoint

### DIFF
--- a/course_discovery/apps/enterprise_catalogs/serializers.py
+++ b/course_discovery/apps/enterprise_catalogs/serializers.py
@@ -93,6 +93,7 @@ class EnterpriseCatalogCourseDetailSerializer(EnterpriseCatalogSerializerMixin, 
 
     _extra_description_cache = None
     title = serializers.CharField(source='course.title')
+    card_image_url = serializers.URLField(source='course.card_image_url', allow_null=True)
     overview = serializers.CharField(source='course.full_description', allow_null=True)
     outline = serializers.CharField(source='course.syllabus_raw', allow_null=True)
     prerequisites = serializers.CharField(source='course.prerequisites_raw', allow_null=True)
@@ -108,6 +109,7 @@ class EnterpriseCatalogCourseDetailSerializer(EnterpriseCatalogSerializerMixin, 
         model = CourseRun
         fields = (
             'title',
+            'card_image_url',
             'overview',
             'outline',
             'prerequisites',


### PR DESCRIPTION
# Description:

This PR updates the EnterpriseCatalogCourseDetailSerializer to expose the card_image_url field for the course detail endpoint.

The MFE requires this field to render the course card image on the detail page. When the course has no card_image_url, the field returns null.

## Key changes:

Added card_image_url = serializers.URLField(source='course.card_image_url', allow_null=True)
Added 'card_image_url' to fields in Meta, after 'title'
## How to Test:
Ensure at least one CourseRun has a card_image_url populated.
Retrieve a course detail:

```bash
{{baseUrlDiscovery}}enterprise_catalogs/<catalog_uuid/courses/<course_run_key>/?coupon_code=AAA
```