### PR TITLE
PADV-3191 BE - API Discovery - Add vendor to catalog course list endpoint

### DIFF
--- a/course_discovery/apps/enterprise_catalogs/serializers.py
+++ b/course_discovery/apps/enterprise_catalogs/serializers.py
@@ -79,6 +79,10 @@ class EnterpriseCatalogSerializerMixin:
         """Return duration from extra_description JSON."""
         return self._get_extra_description_data(obj).get('duration')
 
+    def get_vendor(self, obj):
+        """Return vendor name from extra_description JSON."""
+        return self._get_extra_description_data(obj).get('vendor')
+
 
 class EnterpriseCatalogCourseSerializer(EnterpriseCatalogSerializerMixin, serializers.ModelSerializer):
     """Serializer for CourseRun model in enterprise catalog context."""
@@ -89,6 +93,7 @@ class EnterpriseCatalogCourseSerializer(EnterpriseCatalogSerializerMixin, serial
     key = serializers.CharField()
     pacing_type = serializers.CharField()
     duration = serializers.SerializerMethodField()
+    vendor = serializers.SerializerMethodField()
     enrollment_url = serializers.SerializerMethodField()
 
     class Meta:
@@ -100,6 +105,7 @@ class EnterpriseCatalogCourseSerializer(EnterpriseCatalogSerializerMixin, serial
             'key',
             'pacing_type',
             'duration',
+            'vendor',
             'enrollment_url',
         )
 
@@ -140,10 +146,6 @@ class EnterpriseCatalogCourseDetailSerializer(EnterpriseCatalogSerializerMixin, 
             'target_audience',
             'enrollment_url',
         )
-
-    def get_vendor(self, obj):
-        """Return vendor name from extra_description JSON."""
-        return self._get_extra_description_data(obj).get('vendor')
 
     def get_author(self, obj):
         """Return author from extra_description JSON."""


### PR DESCRIPTION
# Description

This PR adds the vendor field to the list endpoint and refactors shared serializer logic into the mixin to ensure consistency between the list and detail endpoints.
Previously, the vendor field was only available in the detail endpoint via extra_description.description. This inconsistency forced consumers to make an additional request to retrieve the vendor when rendering course listings.

# Key changes

Added vendor = serializers.SerializerMethodField() in EnterpriseCatalogCourseSerializer.
Implemented get_vendor using _get_extra_description_data to extract the value from extra_description.description.
Updated fields in Meta accordingly.

# How to Test
Ensure at least one CourseRun has extra_description.description populated as valid JSON with a "vendor" key.

List endpoint:

```bash
{{baseUrlDiscovery}}enterprise_catalogs/<catalog_uuid>/courses/?coupon_code=AAA
```

Detail endpoint:

```bash
{{baseUrlDiscovery}}enterprise_catalogs/<catalog_uuid>/courses/<course_run_key>/?coupon_code=AAA
```

## Verify that:

vendor appears in both responses with matching values.
When "vendor" is not present in extra_description, the field returns null.
No regression in the detail endpoint.