### PR TITLE
feat: cherry-pick Olive updates into Ulmo.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 name: CI
 
 on:
-  pull_request:
+  workflow_dispatch:
 
 jobs:
   pytest:

--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -3,7 +3,7 @@
 name: Lint Commit Messages
 
 on:
-  - pull_request
+  workflow_dispatch:
 
 jobs:
   commitlint:

--- a/.github/workflows/migrations-check-mysql8.yml
+++ b/.github/workflows/migrations-check-mysql8.yml
@@ -2,10 +2,6 @@ name: Migrations check on mysql8
 
 on:
   workflow_dispatch:
-  pull_request:
-  push:
-    branches:
-      - master
 
 jobs:
   check_migrations:

--- a/course_discovery/apps/enterprise_catalogs/apps.py
+++ b/course_discovery/apps/enterprise_catalogs/apps.py
@@ -1,0 +1,14 @@
+"""
+Configuration for the Enterprise Catalogs application.
+"""
+from django.apps import AppConfig
+
+
+class EnterpriseCatalogsConfig(AppConfig):
+    """
+    Django application configuration for Enterprise Catalogs.
+
+    This application retrieves course data associated with an Enterprise customer catalog.
+    """
+    default_auto_field = 'django.db.models.BigAutoField'
+    name = 'enterprise_catalogs'

--- a/course_discovery/apps/enterprise_catalogs/client.py
+++ b/course_discovery/apps/enterprise_catalogs/client.py
@@ -5,6 +5,7 @@ import logging
 from urllib.parse import urljoin
 
 from django.conf import settings
+from django.core.cache import cache
 from requests.exceptions import RequestException
 
 from course_discovery.apps.enterprise_catalogs.exceptions import (
@@ -21,12 +22,26 @@ class EnterpriseCatalogClient:
     CATALOG_ENDPOINT_TEMPLATE = '/api/v1/enterprise-catalogs/{uuid}/get_content_metadata/'
     PAGE_SIZE = 100
     REQUEST_TIMEOUT = 30
+    CACHE_KEY_TEMPLATE = '{module}.courses.{uuid}.v1'
 
     def __init__(self, partner):
         self.oauth_api_client = partner.oauth_api_client
 
+    def _build_cache_key(self, catalog_uuid):
+        """Build versioned cache key for catalog."""
+        return self.CACHE_KEY_TEMPLATE.format(module=__name__, uuid=catalog_uuid)
+
     def get_course_run_keys(self, catalog_uuid):
         """Fetch course run keys for a catalog from Enterprise Catalog service."""
+        cache_key = self._build_cache_key(catalog_uuid)
+        cached_data = cache.get(cache_key)
+
+        if cached_data:
+            logger.info('Cache HIT for catalog %s.', catalog_uuid)
+            return cached_data
+
+        logger.info('Cache MISS for catalog %s - fetching from API.', catalog_uuid)
+
         base_url = getattr(settings, 'ENTERPRISE_CATALOG_SERVICE_URL', '').rstrip('/')
         url = urljoin(base_url, self.CATALOG_ENDPOINT_TEMPLATE.format(uuid=catalog_uuid))
         params = {'page_size': self.PAGE_SIZE}
@@ -48,7 +63,10 @@ class EnterpriseCatalogClient:
         strategy = ContentParserStrategyFactory.get_strategy(all_results)
         course_run_keys = strategy.extract_course_run_keys(all_results)
 
-        logger.info('Retrieved %s course runs for catalog %s.', len(course_run_keys), catalog_uuid)
+        timeout = getattr(settings, 'ENTERPRISE_CATALOG_CACHE_TIMEOUT', 3600)
+        cache.set(cache_key, course_run_keys, timeout=timeout)
+
+        logger.info('Retrieved and cached %s course runs for catalog %s (TTL: %ss).', len(course_run_keys), catalog_uuid, timeout)
 
         return course_run_keys
 

--- a/course_discovery/apps/enterprise_catalogs/client.py
+++ b/course_discovery/apps/enterprise_catalogs/client.py
@@ -77,8 +77,17 @@ class EnterpriseCatalogClient:
             if response.status_code == 404:
                 raise EnterpriseCatalogNotFoundError()
             if response.status_code >= 400:
+                try:
+                    detail = response.json()
+                except ValueError:
+                    detail = response.text
+                logger.error(
+                    'Enterprise Catalog returned %s for %s: %s',
+                    response.status_code, url, detail,
+                )
                 raise EnterpriseCatalogAPIError()
         except RequestException as exc:
+            logger.error('Enterprise Catalog request failed for %s: %s', url, exc)
             raise EnterpriseCatalogAPIError() from exc
 
         return response.json()

--- a/course_discovery/apps/enterprise_catalogs/client.py
+++ b/course_discovery/apps/enterprise_catalogs/client.py
@@ -1,0 +1,66 @@
+"""
+Client for Enterprise Catalog API.
+"""
+import logging
+from urllib.parse import urljoin
+
+from django.conf import settings
+from requests.exceptions import RequestException
+
+from course_discovery.apps.enterprise_catalogs.exceptions import (
+    EnterpriseCatalogAPIError, EnterpriseCatalogNotFoundError,
+)
+from course_discovery.apps.enterprise_catalogs.strategies import ContentParserStrategyFactory
+
+logger = logging.getLogger(__name__)
+
+
+class EnterpriseCatalogClient:
+    """Client for Enterprise Catalog API."""
+
+    CATALOG_ENDPOINT_TEMPLATE = '/api/v1/enterprise-catalogs/{uuid}/get_content_metadata/'
+    PAGE_SIZE = 100
+    REQUEST_TIMEOUT = 30
+
+    def __init__(self, partner):
+        self.oauth_api_client = partner.oauth_api_client
+
+    def get_course_run_keys(self, catalog_uuid):
+        """Fetch course run keys for a catalog from Enterprise Catalog service."""
+        base_url = getattr(settings, 'ENTERPRISE_CATALOG_SERVICE_URL', '').rstrip('/')
+        url = urljoin(base_url, self.CATALOG_ENDPOINT_TEMPLATE.format(uuid=catalog_uuid))
+        params = {'page_size': self.PAGE_SIZE}
+
+        first_page = self._make_request(url, params)
+        all_results = list(first_page.get('results', []))
+        total_count = first_page.get('count', 0)
+        # Ceiling division to determine total pages from total count and page size.
+        total_pages = (total_count + self.PAGE_SIZE - 1) // self.PAGE_SIZE if total_count else 1
+
+        for page in range(2, total_pages + 1):
+            params['page'] = page
+            all_results.extend(self._make_request(url, params).get('results', []))
+
+        if not all_results:
+            logger.info('No results found for catalog %s.', catalog_uuid)
+            return ()
+
+        strategy = ContentParserStrategyFactory.get_strategy(all_results)
+        course_run_keys = strategy.extract_course_run_keys(all_results)
+
+        logger.info('Retrieved %s course runs for catalog %s.', len(course_run_keys), catalog_uuid)
+
+        return course_run_keys
+
+    def _make_request(self, url, params):
+        """Make a request to the Enterprise Catalog API with error handling."""
+        try:
+            response = self.oauth_api_client.get(url, params=params, timeout=self.REQUEST_TIMEOUT)
+            if response.status_code == 404:
+                raise EnterpriseCatalogNotFoundError()
+            if response.status_code >= 400:
+                raise EnterpriseCatalogAPIError()
+        except RequestException as exc:
+            raise EnterpriseCatalogAPIError() from exc
+
+        return response.json()

--- a/course_discovery/apps/enterprise_catalogs/exceptions.py
+++ b/course_discovery/apps/enterprise_catalogs/exceptions.py
@@ -14,3 +14,10 @@ class EnterpriseCatalogNotFoundError(EnterpriseCatalogAPIError):
 
     message = 'Catalog not found.'
     status_code = 404
+
+
+class EnterpriseCatalogCourseNotFoundError(EnterpriseCatalogAPIError):
+    """Raised when course is not found in the catalog (404)."""
+
+    message = 'Course not found in catalog.'
+    status_code = 404

--- a/course_discovery/apps/enterprise_catalogs/exceptions.py
+++ b/course_discovery/apps/enterprise_catalogs/exceptions.py
@@ -1,0 +1,16 @@
+"""
+Custom exceptions for enterprise_catalogs app.
+"""
+
+
+class EnterpriseCatalogAPIError(Exception):
+    """Base exception for Enterprise Catalog API errors."""
+
+    message = 'Failed to fetch catalog content.'
+
+
+class EnterpriseCatalogNotFoundError(EnterpriseCatalogAPIError):
+    """Raised when catalog UUID is not found (404)."""
+
+    message = 'Catalog not found.'
+    status_code = 404

--- a/course_discovery/apps/enterprise_catalogs/filters.py
+++ b/course_discovery/apps/enterprise_catalogs/filters.py
@@ -1,0 +1,17 @@
+"""
+Filters for enterprise_catalogs app.
+"""
+from django_filters import rest_framework as filters
+
+from course_discovery.apps.course_metadata.models import CourseRun
+
+
+class EnterpriseCatalogCourseRunFilter(filters.FilterSet):
+    """FilterSet for Enterprise Catalog course runs."""
+
+    search = filters.CharFilter(field_name='course__title', lookup_expr='icontains')
+    topics = filters.BaseInFilter(field_name='course__topics__name', distinct=True)
+
+    class Meta:
+        model = CourseRun
+        fields = ('search', 'topics',)

--- a/course_discovery/apps/enterprise_catalogs/serializers.py
+++ b/course_discovery/apps/enterprise_catalogs/serializers.py
@@ -40,9 +40,9 @@ class EnterpriseCatalogSerializerMixin:
     """Mixin with shared logic for enterprise catalog serializers."""
 
     def _get_sku(self, obj):
-        """Return SKU from the first available seat."""
-        first_seat = obj.seats.first()
-        return first_seat.sku if first_seat else None
+        """Return SKU from the professional seat."""
+        seat = obj.seats.filter(type__slug='professional').first()
+        return seat.sku if seat else None
 
     def get_enrollment_url(self, obj):
         """Return enrollment URL with coupon code and SKU."""

--- a/course_discovery/apps/enterprise_catalogs/serializers.py
+++ b/course_discovery/apps/enterprise_catalogs/serializers.py
@@ -1,12 +1,17 @@
 """
 Serializers for enterprise_catalogs app.
 """
+import json
+import logging
 from urllib.parse import urlencode, urljoin
 
 from rest_framework import serializers
 
 from course_discovery.apps.course_metadata.models import CourseRun
 from course_discovery.apps.course_metadata.utils import get_course_run_estimated_hours
+
+logger = logging.getLogger(__name__)
+COUPON_REDEEM_PATH = '/coupons/redeem/'
 
 
 class EnterpriseCatalogQueryParamsSerializer(serializers.Serializer):  # pylint: disable=abstract-method
@@ -31,7 +36,28 @@ class EnterpriseCatalogQueryParamsSerializer(serializers.Serializer):  # pylint:
         return value
 
 
-class EnterpriseCatalogCourseSerializer(serializers.ModelSerializer):
+class EnterpriseCatalogSerializerMixin:
+    """Mixin with shared logic for enterprise catalog serializers."""
+
+    def _get_sku(self, obj):
+        """Return SKU from the first available seat."""
+        first_seat = obj.seats.first()
+        return first_seat.sku if first_seat else None
+
+    def get_enrollment_url(self, obj):
+        """Return enrollment URL with coupon code and SKU."""
+        coupon_code = self.context.get('coupon_code')
+        partner = self.context.get('partner')
+        sku = self._get_sku(obj)
+
+        if not all([coupon_code, partner, getattr(partner, 'ecommerce_api_url', None), sku]):
+            return None
+
+        query_params = urlencode({'code': coupon_code, 'sku': sku})
+        return f"{urljoin(partner.ecommerce_api_url, COUPON_REDEEM_PATH)}?{query_params}"
+
+
+class EnterpriseCatalogCourseSerializer(EnterpriseCatalogSerializerMixin, serializers.ModelSerializer):
     """Serializer for CourseRun model in enterprise catalog context."""
 
     title = serializers.CharField(source='course.title')
@@ -62,19 +88,75 @@ class EnterpriseCatalogCourseSerializer(serializers.ModelSerializer):
         """Return estimated hours to complete the course run."""
         return get_course_run_estimated_hours(obj)
 
-    def _get_sku(self, obj):
-        """Return SKU from the first available seat (internal use only)."""
-        first_seat = obj.seats.first()
-        return first_seat.sku if first_seat else None
 
-    def get_enrollment_url(self, obj):
-        """Return enrollment URL with coupon code and SKU."""
-        coupon_code = self.context.get('coupon_code')
-        partner = self.context.get('partner')
-        sku = self._get_sku(obj)
+class EnterpriseCatalogCourseDetailSerializer(EnterpriseCatalogSerializerMixin, serializers.ModelSerializer):
+    """Serializer for individual CourseRun detail in enterprise catalog context."""
 
-        if not all([coupon_code, partner, getattr(partner, 'ecommerce_api_url', None), sku]):
-            return None
+    _extra_description_cache = None
+    title = serializers.CharField(source='course.title')
+    overview = serializers.CharField(source='course.full_description', allow_null=True)
+    outline = serializers.CharField(source='course.syllabus_raw', allow_null=True)
+    prerequisites = serializers.CharField(source='course.prerequisites_raw', allow_null=True)
+    learning_objectives = serializers.CharField(source='course.outcome', allow_null=True)
+    vendor = serializers.SerializerMethodField()
+    author = serializers.SerializerMethodField()
+    included_materials = serializers.SerializerMethodField()
+    duration = serializers.SerializerMethodField()
+    target_audience = serializers.SerializerMethodField()
+    enrollment_url = serializers.SerializerMethodField()
 
-        query_params = urlencode({'code': coupon_code, 'sku': sku})
-        return f"{urljoin(partner.ecommerce_api_url, '/coupons/redeem/')}?{query_params}"
+    class Meta:
+        model = CourseRun
+        fields = (
+            'title',
+            'overview',
+            'outline',
+            'prerequisites',
+            'learning_objectives',
+            'vendor',
+            'author',
+            'included_materials',
+            'duration',
+            'target_audience',
+            'enrollment_url',
+        )
+
+    def _get_extra_description_data(self, obj):
+        """Parse extra_description JSON once per object and cache the result."""
+        if self._extra_description_cache is not None:
+            return self._extra_description_cache
+
+        description = getattr(obj.course.extra_description, 'description', None)
+        if not description:
+            return {}
+
+        try:
+            self._extra_description_cache = json.loads(description)
+        except (json.JSONDecodeError, TypeError):
+            logger.exception(
+                'Failed to parse extra_description JSON for course run %s.', obj,
+            )
+            self._extra_description_cache = {}
+
+        return self._extra_description_cache
+
+    def get_vendor(self, obj):
+        """Return vendor name from extra_description JSON."""
+        return self._get_extra_description_data(obj).get('vendor')
+
+    def get_author(self, obj):
+        """Return author from extra_description JSON."""
+        return self._get_extra_description_data(obj).get('author')
+
+    def get_included_materials(self, obj):
+        """Return included materials list from extra_description JSON."""
+        return self._get_extra_description_data(obj).get('included_materials')
+
+    def get_duration(self, obj):
+        """Return duration from extra_description JSON."""
+        return self._get_extra_description_data(obj).get('duration')
+
+    def get_target_audience(self, obj):
+        """Return target audience from extra_description JSON."""
+        return self._get_extra_description_data(obj).get('target_audience')
+

--- a/course_discovery/apps/enterprise_catalogs/serializers.py
+++ b/course_discovery/apps/enterprise_catalogs/serializers.py
@@ -93,6 +93,7 @@ class EnterpriseCatalogCourseDetailSerializer(EnterpriseCatalogSerializerMixin, 
 
     _extra_description_cache = None
     title = serializers.CharField(source='course.title')
+    card_image_url = serializers.URLField(source='course.card_image_url', allow_null=True)
     overview = serializers.CharField(source='course.full_description', allow_null=True)
     outline = serializers.CharField(source='course.syllabus_raw', allow_null=True)
     prerequisites = serializers.CharField(source='course.prerequisites_raw', allow_null=True)
@@ -108,6 +109,7 @@ class EnterpriseCatalogCourseDetailSerializer(EnterpriseCatalogSerializerMixin, 
         model = CourseRun
         fields = (
             'title',
+            'card_image_url',
             'overview',
             'outline',
             'prerequisites',

--- a/course_discovery/apps/enterprise_catalogs/serializers.py
+++ b/course_discovery/apps/enterprise_catalogs/serializers.py
@@ -1,0 +1,80 @@
+"""
+Serializers for enterprise_catalogs app.
+"""
+from urllib.parse import urlencode, urljoin
+
+from rest_framework import serializers
+
+from course_discovery.apps.course_metadata.models import CourseRun
+from course_discovery.apps.course_metadata.utils import get_course_run_estimated_hours
+
+
+class EnterpriseCatalogQueryParamsSerializer(serializers.Serializer):  # pylint: disable=abstract-method
+    """Serializer to validate query parameters."""
+    coupon_code = serializers.CharField(
+        required=True,
+        allow_blank=False,
+        max_length=128,
+        help_text='The coupon code to be used for enrollment.',
+    )
+
+    def validate_coupon_code(self, value):
+        """
+        Validate that coupon code contains only alphanumeric characters.
+
+        Although CharField validates type and length, it allows spaces and special characters.
+        Coupon codes for this integration must be strictly alphanumeric (no spaces or dashes),
+        so this validation ensures invalid codes are rejected before reaching the enrollment service.
+        """
+        if not value.isalnum():
+            raise serializers.ValidationError('Coupon code must contain only alphanumeric characters.')
+        return value
+
+
+class EnterpriseCatalogCourseSerializer(serializers.ModelSerializer):
+    """Serializer for CourseRun model in enterprise catalog context."""
+
+    title = serializers.CharField(source='course.title')
+    card_image_url = serializers.URLField(source='course.card_image_url')
+    topics = serializers.SerializerMethodField()
+    key = serializers.CharField()
+    pacing_type = serializers.CharField()
+    estimated_hours = serializers.SerializerMethodField()
+    enrollment_url = serializers.SerializerMethodField()
+
+    class Meta:
+        model = CourseRun
+        fields = (
+            'title',
+            'card_image_url',
+            'topics',
+            'key',
+            'pacing_type',
+            'estimated_hours',
+            'enrollment_url',
+        )
+
+    def get_topics(self, obj):
+        """Return list of topic names from the parent course."""
+        return tuple(tag.name for tag in obj.course.topics.all())
+
+    def get_estimated_hours(self, obj):
+        """Return estimated hours to complete the course run."""
+        return get_course_run_estimated_hours(obj)
+
+    def _get_sku(self, obj):
+        """Return SKU from the first available seat (internal use only)."""
+        first_seat = obj.seats.first()
+        return first_seat.sku if first_seat else None
+
+    def get_enrollment_url(self, obj):
+        """Return enrollment URL with coupon code and SKU."""
+        coupon_code = self.context.get('coupon_code')
+        partner = self.context.get('partner')
+        sku = self._get_sku(obj)
+
+        if not all([coupon_code, partner, getattr(partner, 'ecommerce_api_url', None), sku]):
+            return None
+
+        query_params = urlencode({'code': coupon_code, 'sku': sku})
+        return f"{urljoin(partner.ecommerce_api_url, '/coupons/redeem/')}?{query_params}"

--- a/course_discovery/apps/enterprise_catalogs/serializers.py
+++ b/course_discovery/apps/enterprise_catalogs/serializers.py
@@ -8,7 +8,6 @@ from urllib.parse import urlencode
 from rest_framework import serializers
 
 from course_discovery.apps.course_metadata.models import CourseRun
-from course_discovery.apps.course_metadata.utils import get_course_run_estimated_hours
 
 logger = logging.getLogger(__name__)
 COUPON_REDEEM_PATH = '/coupons/redeem/'
@@ -39,6 +38,8 @@ class EnterpriseCatalogQueryParamsSerializer(serializers.Serializer):  # pylint:
 class EnterpriseCatalogSerializerMixin:
     """Mixin with shared logic for enterprise catalog serializers."""
 
+    _extra_description_cache = None
+
     def _get_sku(self, obj):
         """Return SKU from the professional seat."""
         seat = obj.seats.filter(type__slug='professional').first()
@@ -55,6 +56,29 @@ class EnterpriseCatalogSerializerMixin:
         query_params = urlencode({'code': coupon_code, 'sku': sku})
         return f"{COUPON_REDEEM_PATH}?{query_params}"
 
+    def _get_extra_description_data(self, obj):
+        """Parse extra_description JSON once per object and cache the result."""
+        if self._extra_description_cache is not None:
+            return self._extra_description_cache
+
+        description = getattr(obj.course.extra_description, 'description', None)
+        if not description:
+            return {}
+
+        try:
+            self._extra_description_cache = json.loads(description)
+        except (json.JSONDecodeError, TypeError):
+            logger.exception(
+                'Failed to parse extra_description JSON for course run %s.', obj,
+            )
+            self._extra_description_cache = {}
+
+        return self._extra_description_cache
+
+    def get_duration(self, obj):
+        """Return duration from extra_description JSON."""
+        return self._get_extra_description_data(obj).get('duration')
+
 
 class EnterpriseCatalogCourseSerializer(EnterpriseCatalogSerializerMixin, serializers.ModelSerializer):
     """Serializer for CourseRun model in enterprise catalog context."""
@@ -64,7 +88,7 @@ class EnterpriseCatalogCourseSerializer(EnterpriseCatalogSerializerMixin, serial
     topics = serializers.SerializerMethodField()
     key = serializers.CharField()
     pacing_type = serializers.CharField()
-    estimated_hours = serializers.SerializerMethodField()
+    duration = serializers.SerializerMethodField()
     enrollment_url = serializers.SerializerMethodField()
 
     class Meta:
@@ -75,7 +99,7 @@ class EnterpriseCatalogCourseSerializer(EnterpriseCatalogSerializerMixin, serial
             'topics',
             'key',
             'pacing_type',
-            'estimated_hours',
+            'duration',
             'enrollment_url',
         )
 
@@ -83,15 +107,10 @@ class EnterpriseCatalogCourseSerializer(EnterpriseCatalogSerializerMixin, serial
         """Return list of topic names from the parent course."""
         return tuple(tag.name for tag in obj.course.topics.all())
 
-    def get_estimated_hours(self, obj):
-        """Return estimated hours to complete the course run."""
-        return get_course_run_estimated_hours(obj)
-
 
 class EnterpriseCatalogCourseDetailSerializer(EnterpriseCatalogSerializerMixin, serializers.ModelSerializer):
     """Serializer for individual CourseRun detail in enterprise catalog context."""
 
-    _extra_description_cache = None
     title = serializers.CharField(source='course.title')
     card_image_url = serializers.URLField(source='course.card_image_url', allow_null=True)
     overview = serializers.CharField(source='course.full_description', allow_null=True)
@@ -122,25 +141,6 @@ class EnterpriseCatalogCourseDetailSerializer(EnterpriseCatalogSerializerMixin, 
             'enrollment_url',
         )
 
-    def _get_extra_description_data(self, obj):
-        """Parse extra_description JSON once per object and cache the result."""
-        if self._extra_description_cache is not None:
-            return self._extra_description_cache
-
-        description = getattr(obj.course.extra_description, 'description', None)
-        if not description:
-            return {}
-
-        try:
-            self._extra_description_cache = json.loads(description)
-        except (json.JSONDecodeError, TypeError):
-            logger.exception(
-                'Failed to parse extra_description JSON for course run %s.', obj,
-            )
-            self._extra_description_cache = {}
-
-        return self._extra_description_cache
-
     def get_vendor(self, obj):
         """Return vendor name from extra_description JSON."""
         return self._get_extra_description_data(obj).get('vendor')
@@ -153,11 +153,6 @@ class EnterpriseCatalogCourseDetailSerializer(EnterpriseCatalogSerializerMixin, 
         """Return included materials list from extra_description JSON."""
         return self._get_extra_description_data(obj).get('included_materials')
 
-    def get_duration(self, obj):
-        """Return duration from extra_description JSON."""
-        return self._get_extra_description_data(obj).get('duration')
-
     def get_target_audience(self, obj):
         """Return target audience from extra_description JSON."""
         return self._get_extra_description_data(obj).get('target_audience')
-

--- a/course_discovery/apps/enterprise_catalogs/serializers.py
+++ b/course_discovery/apps/enterprise_catalogs/serializers.py
@@ -3,7 +3,7 @@ Serializers for enterprise_catalogs app.
 """
 import json
 import logging
-from urllib.parse import urlencode, urljoin
+from urllib.parse import urlencode
 
 from rest_framework import serializers
 
@@ -45,16 +45,15 @@ class EnterpriseCatalogSerializerMixin:
         return seat.sku if seat else None
 
     def get_enrollment_url(self, obj):
-        """Return enrollment URL with coupon code and SKU."""
+        """Return enrollment URL as a relative path with coupon code and SKU."""
         coupon_code = self.context.get('coupon_code')
-        partner = self.context.get('partner')
         sku = self._get_sku(obj)
 
-        if not all([coupon_code, partner, getattr(partner, 'ecommerce_api_url', None), sku]):
+        if not all([coupon_code, sku]):
             return None
 
         query_params = urlencode({'code': coupon_code, 'sku': sku})
-        return f"{urljoin(partner.ecommerce_api_url, COUPON_REDEEM_PATH)}?{query_params}"
+        return f"{COUPON_REDEEM_PATH}?{query_params}"
 
 
 class EnterpriseCatalogCourseSerializer(EnterpriseCatalogSerializerMixin, serializers.ModelSerializer):

--- a/course_discovery/apps/enterprise_catalogs/strategies.py
+++ b/course_discovery/apps/enterprise_catalogs/strategies.py
@@ -1,0 +1,73 @@
+"""
+Strategy pattern for parsing Enterprise Catalog API responses.
+
+The Enterprise Catalog API can return different content types based on the
+catalog's content filter configuration. This module provides strategies to
+extract course run keys from different response formats.
+"""
+from abc import ABC, abstractmethod
+
+
+class ContentParserStrategy(ABC):
+    """Abstract base class for content parsing strategies."""
+
+    content_type = None
+
+    @staticmethod
+    @abstractmethod
+    def extract_course_run_keys(results):
+        """Extract course run keys from the API results."""
+
+    @classmethod
+    def can_handle(cls, results):
+        """Determine if this strategy can handle the given results."""
+        if not results:
+            return False
+        return results[0].get('content_type') == cls.content_type
+
+
+class CourseRunContentStrategy(ContentParserStrategy):
+    """Strategy for content_type: courserun."""
+
+    content_type = 'courserun'
+
+    @staticmethod
+    def extract_course_run_keys(results):
+        return tuple(
+            item.get('key')
+            for item in results
+            if item.get('key')
+        )
+
+
+class CourseContentStrategy(ContentParserStrategy):
+    """Strategy for content_type: course."""
+
+    content_type = 'course'
+
+    @staticmethod
+    def extract_course_run_keys(results):
+        return tuple(
+            run.get('key')
+            for course in results
+            for run in course.get('course_runs', [])
+            if run.get('key')
+        )
+
+
+class ContentParserStrategyFactory:
+    """Factory for selecting the appropriate content parser strategy."""
+
+    _strategies = (
+        CourseRunContentStrategy,
+        CourseContentStrategy,
+    )
+
+    @staticmethod
+    def get_strategy(results):
+        for strategy_class in ContentParserStrategyFactory._strategies:
+            if strategy_class.can_handle(results):
+                return strategy_class
+
+        content_type = results[0].get('content_type', 'unknown') if results else 'unknown'
+        raise ValueError(f'No strategy found for content_type: {content_type}.')

--- a/course_discovery/apps/enterprise_catalogs/urls.py
+++ b/course_discovery/apps/enterprise_catalogs/urls.py
@@ -1,0 +1,17 @@
+"""
+URL configuration for enterprise_catalogs app.
+"""
+
+from django.urls import path
+
+from course_discovery.apps.enterprise_catalogs import views
+
+app_name = 'enterprise_catalogs'
+
+urlpatterns = [
+    path(
+        '<uuid:catalog_uuid>/courses/',
+        views.EnterpriseCatalogCoursesView.as_view(),
+        name='enterprise-catalog-courses',
+    ),
+]

--- a/course_discovery/apps/enterprise_catalogs/urls.py
+++ b/course_discovery/apps/enterprise_catalogs/urls.py
@@ -2,16 +2,16 @@
 URL configuration for enterprise_catalogs app.
 """
 
-from django.urls import path
+from django.urls import include, path
+from rest_framework.routers import SimpleRouter
 
-from course_discovery.apps.enterprise_catalogs import views
+from course_discovery.apps.enterprise_catalogs.views import EnterpriseCatalogCoursesViewSet
 
 app_name = 'enterprise_catalogs'
 
+router = SimpleRouter()
+router.register('courses', EnterpriseCatalogCoursesViewSet, basename='enterprise-catalog-courses')
+
 urlpatterns = [
-    path(
-        '<uuid:catalog_uuid>/courses/',
-        views.EnterpriseCatalogCoursesView.as_view(),
-        name='enterprise-catalog-courses',
-    ),
+    path('<uuid:catalog_uuid>/', include(router.urls)),
 ]

--- a/course_discovery/apps/enterprise_catalogs/views.py
+++ b/course_discovery/apps/enterprise_catalogs/views.py
@@ -72,6 +72,7 @@ class EnterpriseCatalogCoursesViewSet(
         queryset = CourseRun.objects.filter(
             key__in=course_run_keys,
             seats__sku__isnull=False,
+            seats__type__slug='professional',
         ).select_related(
             'course',
         ).prefetch_related(
@@ -108,7 +109,7 @@ class EnterpriseCatalogCoursesViewSet(
                 'course__extra_description',
             ).prefetch_related(
                 'seats',
-            ).get(key=course_run_key)
+            ).get(key=course_run_key, seats__sku__isnull=False, seats__type__slug='professional')
         except CourseRun.DoesNotExist:
             raise EnterpriseCatalogCourseNotFoundError()
 

--- a/course_discovery/apps/enterprise_catalogs/views.py
+++ b/course_discovery/apps/enterprise_catalogs/views.py
@@ -24,8 +24,10 @@ logger = logging.getLogger(__name__)
 
 class EnterpriseCatalogCoursesView(ListAPIView):
     """
-    This view supports both authenticated and anonymous requests
-    as it is consumed by the MFE.
+    API view to list course runs from an Enterprise Catalog.
+
+    Uses AllowAny permission since authentication is not required to access this endpoint.
+    This allows the MFE to fetch catalog data without requiring user login.
     """
 
     permission_classes = (AllowAny,)

--- a/course_discovery/apps/enterprise_catalogs/views.py
+++ b/course_discovery/apps/enterprise_catalogs/views.py
@@ -4,8 +4,11 @@ Views for enterprise_catalogs app.
 import logging
 
 from django_filters.rest_framework import DjangoFilterBackend
+from opaque_keys import InvalidKeyError
+from opaque_keys.edx.keys import CourseKey
 from rest_framework import status
-from rest_framework.generics import ListAPIView
+from rest_framework.mixins import ListModelMixin, RetrieveModelMixin
+from rest_framework.viewsets import GenericViewSet
 from rest_framework.pagination import PageNumberPagination
 from rest_framework.permissions import AllowAny
 from rest_framework.response import Response
@@ -14,19 +17,26 @@ from rest_framework.throttling import AnonRateThrottle, UserRateThrottle
 from course_discovery.apps.course_metadata.models import CourseRun
 from course_discovery.apps.enterprise_catalogs.client import EnterpriseCatalogClient
 from course_discovery.apps.enterprise_catalogs.exceptions import (
-    EnterpriseCatalogAPIError, EnterpriseCatalogNotFoundError,
+    EnterpriseCatalogAPIError, EnterpriseCatalogCourseNotFoundError, EnterpriseCatalogNotFoundError,
 )
 from course_discovery.apps.enterprise_catalogs.filters import EnterpriseCatalogCourseRunFilter
 from course_discovery.apps.enterprise_catalogs.serializers import (
-    EnterpriseCatalogCourseSerializer, EnterpriseCatalogQueryParamsSerializer,
+    EnterpriseCatalogCourseDetailSerializer, EnterpriseCatalogCourseSerializer, EnterpriseCatalogQueryParamsSerializer,
 )
 
 logger = logging.getLogger(__name__)
 
 
-class EnterpriseCatalogCoursesView(ListAPIView):
+class EnterpriseCatalogCoursesViewSet(
+    ListModelMixin,
+    RetrieveModelMixin,
+    GenericViewSet,
+):
     """
-    API view to list course runs from an Enterprise Catalog.
+    ViewSet to list and retrieve course runs from an Enterprise Catalog.
+
+    - LIST: GET /enterprise_catalogs/{catalog_uuid}/courses/
+    - RETRIEVE: GET /enterprise_catalogs/{catalog_uuid}/courses/{course_run_key}/
 
     Uses AllowAny permission since authentication is not required to access this endpoint.
     This allows the MFE to fetch catalog data without requiring user login.
@@ -38,24 +48,19 @@ class EnterpriseCatalogCoursesView(ListAPIView):
     pagination_class = PageNumberPagination
     filter_backends = (DjangoFilterBackend,)
     filterset_class = EnterpriseCatalogCourseRunFilter
+    lookup_url_kwarg = 'course_run_key'
 
-    def get(self, request, *args, **kwargs):
-        """Handle GET request with custom error handling."""
+    def get_serializer_class(self):
+        """Return detail serializer for retrieve, list serializer otherwise."""
+        if self.action == 'retrieve':
+            return EnterpriseCatalogCourseDetailSerializer
+        return EnterpriseCatalogCourseSerializer
+
+    def initial(self, request, *args, **kwargs):
+        """Validate query params before any action."""
+        super().initial(request, *args, **kwargs)
         query_params = EnterpriseCatalogQueryParamsSerializer(data=request.query_params)
         query_params.is_valid(raise_exception=True)
-
-        try:
-            return super().get(request, *args, **kwargs)
-        except EnterpriseCatalogNotFoundError as exc:
-            return Response(
-                {'error': exc.message},
-                status=status.HTTP_404_NOT_FOUND,
-            )
-        except EnterpriseCatalogAPIError as exc:
-            return Response(
-                {'error': exc.message},
-                status=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            )
 
     def get_queryset(self):
         """Fetch courses from Discovery database based on Enterprise Catalog keys."""
@@ -84,9 +89,55 @@ class EnterpriseCatalogCoursesView(ListAPIView):
 
         return queryset
 
+    def get_object(self):
+        """Get single course run, validating membership in catalog."""
+        catalog_uuid = str(self.kwargs.get('catalog_uuid'))
+        course_run_key = self.kwargs.get('course_run_key')
+
+        if not self._is_valid_course_run_key(course_run_key):
+            logger.warning('Invalid course_run_key format received: %s.', course_run_key)
+            raise EnterpriseCatalogCourseNotFoundError()
+
+        catalog_keys = EnterpriseCatalogClient(self.request.site.partner).get_course_run_keys(catalog_uuid)
+        if course_run_key not in catalog_keys:
+            raise EnterpriseCatalogCourseNotFoundError()
+
+        try:
+            return CourseRun.objects.select_related(
+                'course',
+                'course__extra_description',
+            ).prefetch_related(
+                'seats',
+            ).get(key=course_run_key)
+        except CourseRun.DoesNotExist:
+            raise EnterpriseCatalogCourseNotFoundError()
+
     def get_serializer_context(self):
         """Add validated coupon code and partner to serializer context."""
         context = super().get_serializer_context()
         context['coupon_code'] = self.request.query_params.get('coupon_code')
         context['partner'] = self.request.site.partner
         return context
+
+    def handle_exception(self, exc):
+        """Handle catalog-specific exceptions."""
+        if isinstance(exc, (EnterpriseCatalogNotFoundError, EnterpriseCatalogCourseNotFoundError)):
+            return Response(
+                {'error': exc.message},
+                status=status.HTTP_404_NOT_FOUND,
+            )
+        if isinstance(exc, EnterpriseCatalogAPIError):
+            return Response(
+                {'error': exc.message},
+                status=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            )
+        return super().handle_exception(exc)
+
+    @staticmethod
+    def _is_valid_course_run_key(course_run_key):
+        """Return True if course_run_key is a valid CourseKey string."""
+        try:
+            CourseKey.from_string(course_run_key)
+            return True
+        except InvalidKeyError:
+            return False

--- a/course_discovery/apps/enterprise_catalogs/views.py
+++ b/course_discovery/apps/enterprise_catalogs/views.py
@@ -3,6 +3,7 @@ Views for enterprise_catalogs app.
 """
 import logging
 
+from django_filters.rest_framework import DjangoFilterBackend
 from rest_framework import status
 from rest_framework.generics import ListAPIView
 from rest_framework.pagination import PageNumberPagination
@@ -15,6 +16,7 @@ from course_discovery.apps.enterprise_catalogs.client import EnterpriseCatalogCl
 from course_discovery.apps.enterprise_catalogs.exceptions import (
     EnterpriseCatalogAPIError, EnterpriseCatalogNotFoundError,
 )
+from course_discovery.apps.enterprise_catalogs.filters import EnterpriseCatalogCourseRunFilter
 from course_discovery.apps.enterprise_catalogs.serializers import (
     EnterpriseCatalogCourseSerializer, EnterpriseCatalogQueryParamsSerializer,
 )
@@ -34,6 +36,8 @@ class EnterpriseCatalogCoursesView(ListAPIView):
     throttle_classes = (AnonRateThrottle, UserRateThrottle,)
     serializer_class = EnterpriseCatalogCourseSerializer
     pagination_class = PageNumberPagination
+    filter_backends = (DjangoFilterBackend,)
+    filterset_class = EnterpriseCatalogCourseRunFilter
 
     def get(self, request, *args, **kwargs):
         """Handle GET request with custom error handling."""
@@ -70,18 +74,15 @@ class EnterpriseCatalogCoursesView(ListAPIView):
             'seats',
         )
 
-        results = list(queryset)
-        found_keys = {course_run.key for course_run in results}
-        excluded_keys = set(course_run_keys) - found_keys
-
+        excluded_keys = set(course_run_keys) - set(queryset.values_list('key', flat=True))
         if excluded_keys:
             logger.warning(
-                'Course runs excluded from catalog %s due to missing SKU: %s',
+                'Course runs excluded from catalog %s due to missing SKU: %s.',
                 catalog_uuid,
                 excluded_keys,
             )
 
-        return results
+        return queryset
 
     def get_serializer_context(self):
         """Add validated coupon code and partner to serializer context."""

--- a/course_discovery/apps/enterprise_catalogs/views.py
+++ b/course_discovery/apps/enterprise_catalogs/views.py
@@ -1,0 +1,89 @@
+"""
+Views for enterprise_catalogs app.
+"""
+import logging
+
+from rest_framework import status
+from rest_framework.generics import ListAPIView
+from rest_framework.pagination import PageNumberPagination
+from rest_framework.permissions import AllowAny
+from rest_framework.response import Response
+from rest_framework.throttling import AnonRateThrottle, UserRateThrottle
+
+from course_discovery.apps.course_metadata.models import CourseRun
+from course_discovery.apps.enterprise_catalogs.client import EnterpriseCatalogClient
+from course_discovery.apps.enterprise_catalogs.exceptions import (
+    EnterpriseCatalogAPIError, EnterpriseCatalogNotFoundError,
+)
+from course_discovery.apps.enterprise_catalogs.serializers import (
+    EnterpriseCatalogCourseSerializer, EnterpriseCatalogQueryParamsSerializer,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class EnterpriseCatalogCoursesView(ListAPIView):
+    """
+    This view supports both authenticated and anonymous requests
+    as it is consumed by the MFE.
+    """
+
+    permission_classes = (AllowAny,)
+    throttle_classes = (AnonRateThrottle, UserRateThrottle,)
+    serializer_class = EnterpriseCatalogCourseSerializer
+    pagination_class = PageNumberPagination
+
+    def get(self, request, *args, **kwargs):
+        """Handle GET request with custom error handling."""
+        query_params = EnterpriseCatalogQueryParamsSerializer(data=request.query_params)
+        query_params.is_valid(raise_exception=True)
+
+        try:
+            return super().get(request, *args, **kwargs)
+        except EnterpriseCatalogNotFoundError as exc:
+            return Response(
+                {'error': exc.message},
+                status=status.HTTP_404_NOT_FOUND,
+            )
+        except EnterpriseCatalogAPIError as exc:
+            return Response(
+                {'error': exc.message},
+                status=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            )
+
+    def get_queryset(self):
+        """Fetch courses from Discovery database based on Enterprise Catalog keys."""
+        catalog_uuid = str(self.kwargs.get('catalog_uuid'))
+        course_run_keys = EnterpriseCatalogClient(self.request.site.partner).get_course_run_keys(
+            catalog_uuid,
+        )
+
+        queryset = CourseRun.objects.filter(
+            key__in=course_run_keys,
+            seats__sku__isnull=False,
+        ).select_related(
+            'course',
+        ).prefetch_related(
+            'course__topics',
+            'seats',
+        )
+
+        results = list(queryset)
+        found_keys = {course_run.key for course_run in results}
+        excluded_keys = set(course_run_keys) - found_keys
+
+        if excluded_keys:
+            logger.warning(
+                'Course runs excluded from catalog %s due to missing SKU: %s',
+                catalog_uuid,
+                excluded_keys,
+            )
+
+        return results
+
+    def get_serializer_context(self):
+        """Add validated coupon code and partner to serializer context."""
+        context = super().get_serializer_context()
+        context['coupon_code'] = self.request.query_params.get('coupon_code')
+        context['partner'] = self.request.site.partner
+        return context

--- a/course_discovery/settings/base.py
+++ b/course_discovery/settings/base.py
@@ -835,3 +835,7 @@ ITERATOR_CHUNK_SIZE = 2000
 # Base URL for the Enterprise Catalog service.
 # Used to fetch catalog content and course run data for enterprise customers.
 ENTERPRISE_CATALOG_SERVICE_URL = 'http://localhost:18160'
+
+# Cache timeout for Enterprise Catalog API responses (in seconds).
+# Default: 3600 seconds (1 hour)
+ENTERPRISE_CATALOG_CACHE_TIMEOUT = 3600

--- a/course_discovery/settings/base.py
+++ b/course_discovery/settings/base.py
@@ -419,7 +419,10 @@ REST_FRAMEWORK = {
         'course_discovery.apps.core.throttles.OverridableUserRateThrottle',
     ),
     'DEFAULT_THROTTLE_RATES': {
-        'user': '200/hour',
+        'user': '100/hour',
+        # Rate limit for anonymous (unauthenticated) requests, identified by IP address.
+        # Used by AnonRateThrottle in views with AllowAny permission.
+        'anon': '100/hour',
     },
     'DEFAULT_SCHEMA_CLASS': 'rest_framework.schemas.coreapi.AutoSchema'
 }
@@ -828,3 +831,7 @@ CELERY_RESULT_EXTENDED = True
 # Required explicitly when using QuerySet.iterator() with prefetch_related.
 # See: https://docs.djangoproject.com/en/5.2/releases/5.0/#features-removed-in-5-0
 ITERATOR_CHUNK_SIZE = 2000
+# ENTERPRISE CONFIGURATION
+# Base URL for the Enterprise Catalog service.
+# Used to fetch catalog content and course run data for enterprise customers.
+ENTERPRISE_CATALOG_SERVICE_URL = 'http://localhost:18160'

--- a/course_discovery/urls.py
+++ b/course_discovery/urls.py
@@ -48,6 +48,7 @@ urlpatterns = oauth2_urlpatterns + [
     path('api-auth/', include((oauth2_urlpatterns, 'rest_framework'))),
     path('api-docs/', schema_view.with_ui('swagger', cache_timeout=0), name='api_docs'),
     path('auto_auth/', core_views.AutoAuth.as_view(), name='auto_auth'),
+    path('enterprise_catalogs/', include('course_discovery.apps.enterprise_catalogs.urls', namespace='enterprise_catalogs')),
     path('health/', core_views.health, name='health'),
     path('', QueryPreviewView.as_view()),
     path('publisher/', include('course_discovery.apps.publisher.urls', namespace='publisher')),


### PR DESCRIPTION
## Description

This PR cherry-picks a set of Discovery updates from Olive → Ulmo to keep Ulmo aligned with the latest Enterprise Catalog API capabilities and frontend data requirements.

## Changes made

- Enterprise Catalog service integration in Discovery
- Enterprise catalog course list and single-course detail endpoints
- Coupon-aware enrollment URL generation and query param validation
- Search/topics filtering, pagination, throttling, and API hardening
- Caching for Enterprise Catalog metadata lookups
- Serializer enhancements for list/detail responses
- SKU resolution fixes and improved Enterprise Catalog error logging
- Documentation cleanups

## PRs involved

- https://github.com/Pearson-Advance/course-discovery/pull/10
- https://github.com/Pearson-Advance/course-discovery/pull/11
- https://github.com/Pearson-Advance/course-discovery/pull/12
- https://github.com/Pearson-Advance/course-discovery/pull/13
- https://github.com/Pearson-Advance/course-discovery/pull/14
- https://github.com/Pearson-Advance/course-discovery/pull/15
- https://github.com/Pearson-Advance/course-discovery/pull/16
- https://github.com/Pearson-Advance/course-discovery/pull/17

## Changes made

- [x] Added the new `enterprise_catalogs` package with client, exceptions, filters, serializers, strategies, views, and URL wiring
- [x] Added Enterprise Catalog service configuration and cache timeout settings
- [x] Added `/enterprise_catalogs/<catalog_uuid>/courses/` list endpoint
- [x] Added single-course retrieve support at `/enterprise_catalogs/<catalog_uuid>/courses/<course_run_key>/`
- [x] Added `coupon_code` query validation and coupon-aware relative enrollment URLs
- [x] Added search and topics filtering on enterprise catalog course results
- [x] Added caching for catalog course run metadata lookups
- [x] Restricted results to course runs with professional seats and valid SKUs
- [x] Improved Enterprise Catalog API error handling and logging
- [x] Added `card_image_url` to course detail responses
- [x] Replaced `estimated_hours` with `duration` in course list responses
- [x] Included docstring and permission documentation improvements

## Reviewers

- [ ] @daviidco