### PR TITLE
PADV-3214 BE - API Discovery - Use custom PageNumberPagination to support page_size query param

### DIFF
--- a/course_discovery/apps/enterprise_catalogs/views.py
+++ b/course_discovery/apps/enterprise_catalogs/views.py
@@ -9,11 +9,11 @@ from opaque_keys.edx.keys import CourseKey
 from rest_framework import status
 from rest_framework.mixins import ListModelMixin, RetrieveModelMixin
 from rest_framework.viewsets import GenericViewSet
-from rest_framework.pagination import PageNumberPagination
 from rest_framework.permissions import AllowAny
 from rest_framework.response import Response
 from rest_framework.throttling import AnonRateThrottle, UserRateThrottle
 
+from course_discovery.apps.api.pagination import PageNumberPagination
 from course_discovery.apps.course_metadata.models import CourseRun
 from course_discovery.apps.enterprise_catalogs.client import EnterpriseCatalogClient
 from course_discovery.apps.enterprise_catalogs.exceptions import (


### PR DESCRIPTION
# Description:

This PR updates the pagination used in the EnterpriseCatalogCoursesViewSet to use the project-specific PageNumberPagination implementation.

The custom pagination enables support for the page_size query parameter, allowing the MFE to control the number of results per page dynamically.

## Key changes:

- Replaced DRF default PageNumberPagination import with project-specific implementation:
  from course_discovery.apps.api.pagination import PageNumberPagination
- Enabled page_size query parameter support for list endpoint pagination

### Note: 
The current implementation of PageNumberPagination from course_discovery.apps.api.pagination does not enforce a maximum page size limit, meaning clients can request an arbitrarily large number of results per page.

## How to Test:

Retrieve the course list with and without page_size:

```bash
{{baseUrlDiscovery}}enterprise_catalogs/<catalog_uuid>/courses/
```

Test with custom page size:

```bash
{{baseUrlDiscovery}}enterprise_catalogs/<catalog_uuid>/courses/?page_size=10
```