### PR TITLE
PADV-3238 BE - Deploy Discovery changes to Ulmo

### DIFF
--- a/course_discovery/apps/enterprise_catalogs/serializers.py
+++ b/course_discovery/apps/enterprise_catalogs/serializers.py
@@ -79,6 +79,10 @@ class EnterpriseCatalogSerializerMixin:
         """Return duration from extra_description JSON."""
         return self._get_extra_description_data(obj).get('duration')
 
+    def get_vendor(self, obj):
+        """Return vendor name from extra_description JSON."""
+        return self._get_extra_description_data(obj).get('vendor')
+
 
 class EnterpriseCatalogCourseSerializer(EnterpriseCatalogSerializerMixin, serializers.ModelSerializer):
     """Serializer for CourseRun model in enterprise catalog context."""
@@ -89,6 +93,7 @@ class EnterpriseCatalogCourseSerializer(EnterpriseCatalogSerializerMixin, serial
     key = serializers.CharField()
     pacing_type = serializers.CharField()
     duration = serializers.SerializerMethodField()
+    vendor = serializers.SerializerMethodField()
     enrollment_url = serializers.SerializerMethodField()
 
     class Meta:
@@ -100,6 +105,7 @@ class EnterpriseCatalogCourseSerializer(EnterpriseCatalogSerializerMixin, serial
             'key',
             'pacing_type',
             'duration',
+            'vendor',
             'enrollment_url',
         )
 
@@ -140,10 +146,6 @@ class EnterpriseCatalogCourseDetailSerializer(EnterpriseCatalogSerializerMixin, 
             'target_audience',
             'enrollment_url',
         )
-
-    def get_vendor(self, obj):
-        """Return vendor name from extra_description JSON."""
-        return self._get_extra_description_data(obj).get('vendor')
 
     def get_author(self, obj):
         """Return author from extra_description JSON."""

--- a/course_discovery/apps/enterprise_catalogs/views.py
+++ b/course_discovery/apps/enterprise_catalogs/views.py
@@ -9,11 +9,11 @@ from opaque_keys.edx.keys import CourseKey
 from rest_framework import status
 from rest_framework.mixins import ListModelMixin, RetrieveModelMixin
 from rest_framework.viewsets import GenericViewSet
-from rest_framework.pagination import PageNumberPagination
 from rest_framework.permissions import AllowAny
 from rest_framework.response import Response
 from rest_framework.throttling import AnonRateThrottle, UserRateThrottle
 
+from course_discovery.apps.api.pagination import PageNumberPagination
 from course_discovery.apps.course_metadata.models import CourseRun
 from course_discovery.apps.enterprise_catalogs.client import EnterpriseCatalogClient
 from course_discovery.apps.enterprise_catalogs.exceptions import (


### PR DESCRIPTION
# Description:

This PR migrates the Enterprise Catalog improvements from Olive to Ulmo by cherry-picking the changes related to vendor exposure and pagination behavior.
It ensures feature parity between branches so the Ulmo environment includes the same API capabilities required by the MFE.

# Key changes:

Cherry-picked changes from PADV-3191:
Added vendor field to the EnterpriseCatalogCourseSerializer (list endpoint)
Reused _get_extra_description_data via EnterpriseCatalogSerializerMixin

Cherry-picked changes from PADV-3214:
Replaced DRF default pagination with project-specific implementation:
from course_discovery.apps.api.pagination import PageNumberPagination
Enabled page_size query parameter support for dynamic pagination

### Note:
No new logic was introduced; this PR only ports existing, previously validated changes from Olive.
The current implementation of PageNumberPagination does not enforce a maximum page size limit.

## How to Test:
Retrieve the course list:
```bash
{{baseUrlDiscovery}}enterprise_catalogs/<catalog_uuid>/courses/
```
Validate vendor field:
```bash
{{baseUrlDiscovery}}enterprise_catalogs/<catalog_uuid>/courses/?coupon_code=AAA
```
Test pagination with custom page size:
```bash
{{baseUrlDiscovery}}enterprise_catalogs/<catalog_uuid>/courses/?page_size=10
```

## PRs involved
- https://github.com/Pearson-Advance/course-discovery/pull/20
- https://github.com/Pearson-Advance/course-discovery/pull/18

