### PR TITLE
fix: updates how frontend dependencies are loaded in query-preview.js

### DIFF
--- a/course_discovery/static/js/query-preview.js
+++ b/course_discovery/static/js/query-preview.js
@@ -1,5 +1,8 @@
+var $ = require('jquery');
+window.$ = window.jQuery = $;
+
 require('bootstrap-sass');
-require('datatables.net-bs')();
+require('datatables.net-bs');
 
 var $alertNoResults, $alertQueryInvalid, $query, $table;
 


### PR DESCRIPTION
## Description

This change updates how frontend dependencies are loaded in `query-preview.js`, specifically jQuery and DataTables, to ensure compatibility with the current Ulmo environment (Webpack 5).

## Problem

The original implementation used the following pattern:
`require('datatables.net-bs')();`

In the current environment (Webpack 5 + newer DataTables versions), these patterns cause runtime errors such as:
`TypeError: ... is not a function`

## Root Cause

`query-preview.js` is legacy code (~9 years old) and was designed for:

- older module systems
- older DataTables versions
- different require() behavior

In the current setup:

- Webpack resolves modules differently
- DataTables modules are no longer exposed as callable factories
- instead, they rely on side-effect imports to register themselves
 
## Impact

Because the bundle failed before executing $(document).ready(...), the UI was not initialized properly:

- The Fields table was not rendered
- DataTables was not initialized
- The `#queryForm` submit handler was not attached
- The Search button did not trigger API calls
- The page appeared to return no results despite the backend working correctly


<img width="1870" height="880" alt="Screenshot 2026-04-16 at 17 04 11" src="https://github.com/user-attachments/assets/63bcc118-ddf4-474a-b31f-146d3e13a9a1" />

## How to test

- Build the discovery image using this changes
- Launch the Ulmo environment
- Login in the LMS and go to http://discovery.local.openedx.io:8381/
- See the table complete and test the query with the button

<img width="1920" height="919" alt="Screenshot 2026-04-16 at 19 27 31" src="https://github.com/user-attachments/assets/55b4c05b-303c-46e4-963e-d4fb496dc3ea" />
<img width="1920" height="919" alt="Screenshot 2026-04-16 at 19 27 48" src="https://github.com/user-attachments/assets/5f4aeb27-9215-4b81-9044-18317f8642df" />



