### PR TITLE
fix: fixing view search decorator to obtain all params in post

### DIFF
--- a/course_discovery/apps/api/utils.py
+++ b/course_discovery/apps/api/utils.py
@@ -7,6 +7,7 @@ from urllib.parse import parse_qsl, urlencode, urljoin
 from django.conf import settings
 from django.core.files.base import ContentFile
 from django.db.models.fields.related import ManyToManyField
+from django.http import QueryDict
 from django.utils.translation import gettext as _
 from edx_django_utils.cache import RequestCache
 from opaque_keys.edx.keys import CourseKey
@@ -74,6 +75,13 @@ def update_query_params_with_body_data(func_to_decorate):
     @functools.wraps(func_to_decorate)
     def wrapper(self, request, *args, **kwargs):
         _data = request.data.copy()
+
+        if isinstance(request.data, QueryDict):
+            # When request.data is a QueryDict and it contains list of values for a key, we need to ensure that
+            # we take all values for that key instead of just one.
+            # https://docs.djangoproject.com/en/6.0/ref/request-response/#django.http.QueryDict.lists
+            _data = dict(request.data.lists())
+
         for key, value in _data.items():
             if isinstance(value, (list, tuple)) and len(value) == 1:
                 _data[key] = value[0]


### PR DESCRIPTION
## Ticket

https://pearson.atlassian.net/browse/PADV-3170

## Description

This PR aims to add a more robust fix to the issue with using a list with multiple items as a value for the filters in the /api/v1/search/all endpoint. Previously we added a hot fix to cover this scenario, but we needed to find a more adequate solution.

### Description of issue

Before the fixes, when we were to make a POST request to /api/v1/search/all and used a filter with a list as value, such as:
```
{
    "key":[
        "course-v1:enterprise+test+1",
        "course-v1:enterprise+test+2"
    ]
}
```
The view took into account only the last value and discarded the other ones, in this case, it would only take the `"course-v1:enterprise+test+2"` value as a search filter. This view was intended to accept filters with list values. For our use case, we needed to support enterprise catalog queries with a filter that supported multiple course keys.

## Changes applied

### Reason of the issue

We modified the [decorator](https://github.com/Pearson-Advance/course-discovery/blob/pearson/ulmo/course_discovery/apps/api/utils.py#L61) used in the method POST (create) for the view [AggregateSearchViewSet](https://github.com/Pearson-Advance/course-discovery/blob/pearson/ulmo/course_discovery/apps/api/utils.py#L61), this method transforms the search params inside the POST data of the request into query params inside the request, however because the data comes as a [QueryDict Django object](https://docs.djangoproject.com/en/6.0/ref/request-response/#querydict-objects), when the values are accessed, the default get behavior of this object is to use the last item of a list if the value of a key is of this type (https://docs.djangoproject.com/en/6.0/ref/request-response/#django.http.QueryDict.items).

### Fix applied

Modify the decorator to safely access the values of the QueryDict and transform it to a Python dict object. We applied this fix since is inferred that the view was intended to accept keys with lists of multiple items by this [for loop](https://github.com/Pearson-Advance/course-discovery/blob/pearson/ulmo/course_discovery/apps/api/utils.py#L77-L79), which handles a case when a value has a list of length 1 meaning there is a case where the length may be bigger than 1. We couldn't found any other decisions related to this since the commit where this decorator was added was part of a bundle of several commits.

## How to test

1. Setup tutor ulmo with the discovery service.
2. Create a course and sync the data and update indexes in discovery.
3. Perform a POST request to /api/v1/search/all with a body containing a value of a list of multiple values. Example:
  ```
  {
      "key":[
          "course-v1:enterprise+test+1",
          "course-v1:enterprise+test+2"
      ]
  }
  ```
4. It should return a response with the two course run data.

## Screenshots
<img width="700" alt="Screenshot 2026-05-12 at 10 48 36 PM" src="https://github.com/user-attachments/assets/5f6d6392-547e-4277-89a7-be7b22a5c88d" />
<img width="700" alt="Screenshot 2026-05-12 at 10 48 56 PM" src="https://github.com/user-attachments/assets/5b5a9a80-91bf-4f9f-bfcf-17b85c4d8e48" />
