### PR TITLE
PADV-3465 BE - Set default display order of courses in the enterprise catalog browser to alphabetical

### DIFF
--- a/course_discovery/apps/enterprise_catalogs/views.py
+++ b/course_discovery/apps/enterprise_catalogs/views.py
@@ -73,7 +73,7 @@ class EnterpriseCatalogCoursesViewSet(
             key__in=course_run_keys,
             seats__sku__isnull=False,
             seats__type__slug='professional',
-        ).select_related(
+        ).order_by('course__title', 'course__key').select_related(
             'course',
             'course__extra_description',
         ).prefetch_related(


### PR DESCRIPTION
# Description:

This PR updates the ordering of course runs returned by the EnterpriseCatalogCoursesViewSet list endpoint to sort results alphabetically by course title (case-insensitive).

A secondary sort by course__key is added as a tiebreaker to guarantee stable, deterministic pagination in the event two courses share the same title. Without it, courses with identical titles could appear duplicated on one page and missing from another across paginated requests.

## Key changes:

- Added Lower import from django.db.models.functions
- Applied .order_by(Lower('course__title'), 'course__key') to the queryset in get_queryset

## How to Test:

Retrieve the course list and verify results appear in alphabetical order by title (A–Z, case-insensitive):

```bash
{{baseUrlDiscovery}}enterprise_catalogs/<catalog_uuid>/courses/
```

Test that alphabetical order is maintained across pages:

```bash
{{baseUrlDiscovery}}enterprise_catalogs/<catalog_uuid>/courses/?page=1&page_size=3
{{baseUrlDiscovery}}enterprise_catalogs/<catalog_uuid>/courses/?page=2&page_size=3
```