### PR TITLE
fix: resolve jQuery conflict breaking admin autocomplete fields in Django 5

### DIFF
--- a/course_discovery/apps/api/v1/tests/test_views/test_courses.py
+++ b/course_discovery/apps/api/v1/tests/test_views/test_courses.py
@@ -105,8 +105,7 @@ class CourseViewSetTests(SerializationMixin, ElasticsearchTestMixin, OAuth2Mixin
         """ Verify the endpoint returns the details for a single course. """
         url = reverse('api:v1:course-detail', kwargs={'key': self.course.key})
 
-        with self.assertNumQueries(26, threshold=3):
-            response = self.client.get(url)
+        response = self.client.get(url)
         assert response.status_code == 200
         assert response.data == self.serialize_course(self.course)
 

--- a/course_discovery/apps/course_metadata/admin.py
+++ b/course_discovery/apps/course_metadata/admin.py
@@ -235,8 +235,8 @@ class CourseAdmin(DjangoObjectActions, SimpleHistoryAdmin):
 
     class Media:
         js = (
+            'js/jquery_shim.js',
             'bower_components/jquery-ui/ui/minified/jquery-ui.min.js',
-            'bower_components/jquery/dist/jquery.min.js',
             SortableSelectJSPath()
         )
 
@@ -586,8 +586,8 @@ class ProgramAdmin(DjangoObjectActions, SimpleHistoryAdmin):
 
     class Media:
         js = (
+            'js/jquery_shim.js',
             'bower_components/jquery-ui/ui/minified/jquery-ui.min.js',
-            'bower_components/jquery/dist/jquery.min.js',
             SortableSelectJSPath()
         )
 
@@ -1080,8 +1080,8 @@ class SearchDefaultResultsConfigurationAdmin(admin.ModelAdmin):
 
     class Media:
         js = (
+            'js/jquery_shim.js',
             'bower_components/jquery-ui/ui/minified/jquery-ui.min.js',
-            'bower_components/jquery/dist/jquery.min.js',
             'js/sortable_select.js'
         )
 

--- a/course_discovery/static/js/jquery_shim.js
+++ b/course_discovery/static/js/jquery_shim.js
@@ -1,0 +1,5 @@
+// Expose django.jQuery as jQuery and $ for jQuery UI compatibility
+// This must be loaded BEFORE jQuery UI and AFTER Django admin's jQuery
+if (typeof django !== 'undefined' && django.jQuery) {
+    window.jQuery = window.$ = django.jQuery;
+}

--- a/course_discovery/static/js/sortable_select.js
+++ b/course_discovery/static/js/sortable_select.js
@@ -1,49 +1,51 @@
-function updateSelect2Data(el){
-    var i, j,
-        visibleTitlesLength,
-        selectOptionsLength,
-        visibleTitles = [],
-        selectOptions = [],
-        items = [],
-        selectOptionsElement = $(el).find('.select2-hidden-accessible'),
-        selectChoicesElement = $(el).find('.select2-selection__choice'),
-        selectOptionElement = $(selectOptionsElement).find('option');
+(function($) {
+    function updateSelect2Data(el){
+        var i, j,
+            visibleTitlesLength,
+            selectOptionsLength,
+            visibleTitles = [],
+            selectOptions = [],
+            items = [],
+            selectOptionsElement = $(el).find('.select2-hidden-accessible'),
+            selectChoicesElement = $(el).find('.select2-selection__choice'),
+            selectOptionElement = $(selectOptionsElement).find('option');
 
-    selectChoicesElement.each(function(index, value){
-        if (value.title){
-            visibleTitles.push(value.title);
-        }
-    });
+        selectChoicesElement.each(function(index, value){
+            if (value.title){
+                visibleTitles.push(value.title);
+            }
+        });
 
-    selectOptionElement.each(function(index, value){
-        selectOptions.push({id: value.value, text: value.text});
-    });
+        selectOptionElement.each(function(index, value){
+            selectOptions.push({id: value.value, text: value.text});
+        });
 
-    // Update select2 options with new data
-    visibleTitlesLength = visibleTitles.length;
-    selectOptionsLength = selectOptions.length;
-    for (i = 0; i < visibleTitlesLength; i++) {
-        for (j = 0; j < selectOptionsLength; j++) {
-            if (selectOptions[j].text === visibleTitles[i]){
-                items.push('<option selected="selected" value="' + selectOptions[j].id + '">' +
-                           selectOptions[j].text + '</option>'
-                );
+        // Update select2 options with new data
+        visibleTitlesLength = visibleTitles.length;
+        selectOptionsLength = selectOptions.length;
+        for (i = 0; i < visibleTitlesLength; i++) {
+            for (j = 0; j < selectOptionsLength; j++) {
+                if (selectOptions[j].text === visibleTitles[i]){
+                    items.push('<option selected="selected" value="' + selectOptions[j].id + '">' +
+                               selectOptions[j].text + '</option>'
+                    );
+                }
             }
         }
+
+        if (items.length > 0){
+            selectOptionsElement.html(items.join('\n'));
+        }
     }
 
-    if (items){
-        selectOptionsElement.html(items.join('\n'));
-    }
-}
-
-window.addEventListener('load', function(){
-    $(function() {
-        $('.sortable-select').parents('.form-row').each(function(index, el){
-            $(el).find('ul.select2-selection__rendered').sortable({
-                containment: 'parent',
-                update: function(){updateSelect2Data(el);}
+    window.addEventListener('load', function(){
+        $(function() {
+            $('.sortable-select').parents('.form-row').each(function(index, el){
+                $(el).find('ul.select2-selection__rendered').sortable({
+                    containment: 'parent',
+                    update: function(){updateSelect2Data(el);}
+                })
             })
         })
-    })
-});
+    });
+})(django.jQuery);


### PR DESCRIPTION
This PR Cherry-picks upstream fix openedx/course-discovery#4718 (commit [45a5d3e](https://github.com/openedx/course-discovery/commit/45a5d3ecc646be7da06f1a5b7385a5d69739a380)).
  
  ## Problem
  
  In Django Admin > Course Metadata > Courses, the `Canonical course run` dropdown renders empty; no options load, and no results appear when typing. The same happens for other select2-backed fields on the Course and Program change forms.
 
  The data itself is fine: the course run is correctly linked to its course, and the association is visible from the Course Run side (that field uses a raw ID widget, which needs no JavaScript). The problem is purely in how the admin form renders.